### PR TITLE
Add generic fixed ninth-house capacity

### DIFF
--- a/include/DataTypes.h
+++ b/include/DataTypes.h
@@ -309,8 +309,11 @@ typedef enum
     HOUSE_MERCENARY =  5,
     HOUSE_NEUTRAL   =  6,
     HOUSE_REBELS    =  7,
+    HOUSE_CUSTOM     = 8,
     NUM_HOUSES
 } HOUSETYPE;
+
+constexpr int NUM_LEGACY_HOUSES = 8;
 
 constexpr int HOUSECOLOR_CUSTOM_DARK_VIOLET   = NUM_HOUSES;
 constexpr int HOUSECOLOR_CUSTOM_FUCHSIA       = NUM_HOUSES + 1;
@@ -319,6 +322,13 @@ constexpr int HOUSECOLOR_CUSTOM_BRIGHT_YELLOW = NUM_HOUSES + 3;
 constexpr int HOUSECOLOR_CUSTOM_APPLE_GREEN   = NUM_HOUSES + 4;
 constexpr int HOUSECOLOR_CUSTOM_LIGHT_PINK    = NUM_HOUSES + 5;
 constexpr int NUM_CUSTOM_HOUSE_COLORS         = 6;
+
+constexpr int migrateLegacyHouseColorSlot(int colorSlot) noexcept {
+    return (colorSlot >= NUM_LEGACY_HOUSES
+            && colorSlot < NUM_LEGACY_HOUSES + NUM_CUSTOM_HOUSE_COLORS)
+        ? colorSlot + 1
+        : colorSlot;
+}
 constexpr int NUM_HOUSE_COLOR_SLOTS           = NUM_HOUSES + NUM_CUSTOM_HOUSE_COLORS;
 
 typedef enum {

--- a/include/Definitions.h
+++ b/include/Definitions.h
@@ -32,7 +32,7 @@
 #define SAVEMAGIC           8675309
 // 9820: CitySimulation persists every house's R/C/I and budget state.
 // 9817 added House::cityCredits; 9818 introduced the all-house city layout.
-#define SAVEGAMEVERSION     9820
+#define SAVEGAMEVERSION     9821
 
 // v1.0.0–v1.0.7 shipped SAVEGAMEVERSION 9810 with Num_ItemID=48.
 // v1.0.8–v1.0.10 also used 9810 but with Num_ItemID=52 (4 items added
@@ -84,7 +84,8 @@
 #define INVALID (-1)
 #define INVALID_GAMECYCLE (static_cast<Uint32>(-1))
 
-#define NUM_TEAMS 8
+#define NUM_TEAMS 9
+#define NUM_TEAM_SLOTS (NUM_TEAMS + 1)
 
 #define DEVIATIONTIME MILLI2CYCLES(120*1000)
 #define TRACKSTIME MILLI2CYCLES((1 << 16))

--- a/include/GUI/ObjectInterfaces/PalaceInterface.h
+++ b/include/GUI/ObjectInterfaces/PalaceInterface.h
@@ -97,7 +97,7 @@ protected:
         if(pPalace != nullptr) {
             int picID;
 
-            switch(pPalace->getOriginalHouseID()) {
+            switch(getHouseFallbackHouse(static_cast<HOUSETYPE>(pPalace->getOriginalHouseID()))) {
                 case HOUSE_HARKONNEN:
                 case HOUSE_SARDAUKAR: {
                     picID = Picture_DeathHand;
@@ -151,7 +151,8 @@ private:
 
         Palace* pPalace = dynamic_cast<Palace*>(pObject);
         if(pPalace != nullptr) {
-            if((pPalace->getOriginalHouseID() == HOUSE_HARKONNEN) || (pPalace->getOriginalHouseID() == HOUSE_SARDAUKAR)) {
+            const HOUSETYPE palaceHouse = getHouseFallbackHouse(static_cast<HOUSETYPE>(pPalace->getOriginalHouseID()));
+            if((palaceHouse == HOUSE_HARKONNEN) || (palaceHouse == HOUSE_SARDAUKAR)) {
                 currentGame->setCursorMode(Game::CursorMode_Attack);
             } else {
                 pPalace->handleSpecialClick();

--- a/include/GameInitSettings.h
+++ b/include/GameInitSettings.h
@@ -164,6 +164,7 @@ public:
     ~GameInitSettings();
 
     void save(OutputStream& stream) const;
+    void migrateLegacyHouseColorSlots();
 
     inline GameType getGameType() const { return gameType; };
     inline HOUSETYPE getHouseID() const { return houseID; };

--- a/include/INIMap/MapPlayerSectionUtils.h
+++ b/include/INIMap/MapPlayerSectionUtils.h
@@ -1,0 +1,21 @@
+#ifndef MAPPLAYERSECTIONUTILS_H
+#define MAPPLAYERSECTIONUTILS_H
+
+namespace MapPlayerSectionUtils {
+
+/** Count numbered PlayerN sections across the fixed available-house capacity. */
+template<typename HasSection>
+int countNumberedPlayerSections(int availableHouseCapacity, HasSection&& hasSection) {
+    int count = 0;
+    for(int playerNumber = 1; playerNumber <= availableHouseCapacity; ++playerNumber) {
+        if(hasSection(playerNumber)) {
+            ++count;
+        }
+    }
+
+    return count;
+}
+
+} // namespace MapPlayerSectionUtils
+
+#endif // MAPPLAYERSECTIONUTILS_H

--- a/include/Network/NetworkManager.h
+++ b/include/Network/NetworkManager.h
@@ -70,6 +70,17 @@
 // Version 4: Fixed nine-house deterministic state and versioned visibility storage
 #define NETWORK_PROTOCOL_VERSION            4
 
+/**
+ * Reject an incompatible config-hash handshake and dispatch its disconnect cause.
+ * Returns true when the peer must be rejected.
+ */
+template<typename DisconnectFunction>
+inline bool rejectIncompatibleNetworkProtocol(Uint32 peerProtocolVersion, DisconnectFunction&& disconnect) {
+    if(peerProtocolVersion == NETWORK_PROTOCOL_VERSION) return false;
+    disconnect(NETWORKDISCONNECT_PROTOCOL_MISMATCH);
+    return true;
+}
+
 // Mod transfer limits
 #define MAX_MOD_TRANSFER_SIZE   (10 * 1024 * 1024)  // 10MB max mod size
 #define MOD_CHUNK_SIZE          (64 * 1024)          // 64KB per chunk

--- a/include/Network/NetworkManager.h
+++ b/include/Network/NetworkManager.h
@@ -41,6 +41,7 @@
 #define NETWORKDISCONNECT_TIMEOUT           2
 #define NETWORKDISCONNECT_PLAYER_EXISTS     3
 #define NETWORKDISCONNECT_GAME_FULL         4
+#define NETWORKDISCONNECT_PROTOCOL_MISMATCH 5
 
 #define NETWORKPACKET_UNKNOWN               0
 #define NETWORKPACKET_CONNECT               1
@@ -66,7 +67,8 @@
 // Network protocol version - increment when packet formats change
 // Version 2: Added simMsAvg to NETWORKPACKET_CLIENTSTATS (5 fields instead of 4)
 // Version 3: Added mod transfer packets (MOD_INFO, MOD_REQUEST, MOD_CHUNK, MOD_COMPLETE)
-#define NETWORK_PROTOCOL_VERSION            3
+// Version 4: Fixed nine-house deterministic state and versioned visibility storage
+#define NETWORK_PROTOCOL_VERSION            4
 
 // Mod transfer limits
 #define MAX_MOD_TRANSFER_SIZE   (10 * 1024 * 1024)  // 10MB max mod size

--- a/include/ObjectBase.h
+++ b/include/ObjectBase.h
@@ -230,7 +230,7 @@ protected:
     ObjectPointer target;            ///< The target to attack or move to
     ATTACKMODE    attackMode;        ///< The attack mode of this unit/structure
 
-    std::bitset<NUM_TEAMS> visible;  ///< To which teams is this unit visible?
+    std::bitset<NUM_TEAM_SLOTS> visible;  ///< To which teams is this unit visible?
 
     // drawing information
     bool     badlyDamaged;           ///< Is the health below 50%?

--- a/include/ObjectData.h
+++ b/include/ObjectData.h
@@ -93,7 +93,7 @@ public:
                                count (e.g. LEGACY_NUM_ITEM_ID_9810 for v1.0.7).
         \see save
     */
-    void load(InputStream& stream, int savedItemCount = 0);
+    void load(InputStream& stream, int savedItemCount = 0, int savedHouseCount = NUM_HOUSES);
 
     /**
         Logs all loaded object data to SDL log for debugging.

--- a/include/Tile.h
+++ b/include/Tile.h
@@ -399,8 +399,10 @@ public:
         \param  cycle   the cycle this happens (normally the current game cycle)
     */
     void setExplored(int houseID, Uint32 cycle) {
-        lastAccess[houseID] = cycle;
-        explored[houseID] = true;
+        if(houseID >= 0 && houseID < NUM_HOUSES) {
+            lastAccess[houseID] = cycle;
+            explored[houseID] = true;
+        }
     }
 
     void setOwner(int newOwner) noexcept { owner = newOwner; }
@@ -418,7 +420,7 @@ public:
     bool hasSpice() const noexcept { return (spice > 0); }
     bool infantryNotFull() const noexcept { return (assignedInfantryList.size() < NUM_INFANTRY_PER_TILE); }
     bool isConcrete() const noexcept { return (type == Terrain_Slab); }
-    bool isExploredByHouse(int houseID) const { return explored[houseID]; }
+    bool isExploredByHouse(int houseID) const { return houseID >= 0 && houseID < NUM_HOUSES && explored[houseID]; }
     bool isExploredByTeam(int teamID) const;
 
     bool isFoggedByHouse(int houseID) const noexcept;
@@ -512,8 +514,8 @@ private:
     std::list<Uint32>   assignedUndergroundUnitList;              ///< all underground units on this tile
     std::list<Uint32>   assignedNonInfantryGroundObjectList;      ///< all structures/vehicles on this tile
 
-    Uint32      lastAccess[NUM_TEAMS];    ///< contains for every team when this tile was seen last by this house
-    bool        explored[NUM_TEAMS];      ///< contains for every team if this tile is explored
+    Uint32      lastAccess[NUM_HOUSES];    ///< contains for every team when this tile was seen last by this house
+    bool        explored[NUM_HOUSES];      ///< contains for every team if this tile is explored
 
     // --- DuneCity overlay fields ---
     DuneCity::ZoneType  cityZoneType_ = DuneCity::ZoneType::None;

--- a/include/globals.h
+++ b/include/globals.h
@@ -104,14 +104,16 @@ EXTERN std::array<int, NUM_HOUSES> houseToVisualHouse;  ///< runtime visual colo
 
 
 // constants
-static const int houseToPaletteIndex[NUM_HOUSES] = { PALCOLOR_HARKONNEN, PALCOLOR_ATREIDES, PALCOLOR_ORDOS, PALCOLOR_FREMEN, PALCOLOR_SARDAUKAR, PALCOLOR_MERCENARY, PALCOLOR_NEUTRAL, PALCOLOR_REBELS };    ///< the base colors for the different houses
+static const int houseToPaletteIndex[NUM_HOUSES] = { PALCOLOR_HARKONNEN, PALCOLOR_ATREIDES, PALCOLOR_ORDOS, PALCOLOR_FREMEN, PALCOLOR_SARDAUKAR, PALCOLOR_MERCENARY, PALCOLOR_NEUTRAL, PALCOLOR_REBELS, PALCOLOR_HARKONNEN };    ///< the base colors for the different houses
 static const int houseColorToPaletteIndex[NUM_HOUSE_COLOR_SLOTS] = {
     PALCOLOR_HARKONNEN, PALCOLOR_ATREIDES, PALCOLOR_ORDOS, PALCOLOR_FREMEN,
-    PALCOLOR_SARDAUKAR, PALCOLOR_MERCENARY, PALCOLOR_NEUTRAL, PALCOLOR_REBELS,
+    PALCOLOR_SARDAUKAR, PALCOLOR_MERCENARY, PALCOLOR_NEUTRAL, PALCOLOR_REBELS, PALCOLOR_HARKONNEN,
     PALCOLOR_HARKONNEN, PALCOLOR_ATREIDES, PALCOLOR_ORDOS, PALCOLOR_FREMEN,
     PALCOLOR_SARDAUKAR, PALCOLOR_MERCENARY
 };    ///< palette ramp used by house colors, including custom visual-only colors
-static const char houseChar[] = { 'H', 'A', 'O', 'F', 'S', 'M', 'N', 'R' };   ///< character for each house
+static const char houseChar[] = { 'H', 'A', 'O', 'F', 'S', 'M', 'N', 'R', '?' };   ///< character for each house
+
+int getHousePaletteIndex(HOUSETYPE house);
 
 inline bool isValidHouseColorSlot(int colorSlot) {
     return colorSlot >= 0 && colorSlot < NUM_HOUSE_COLOR_SLOTS;
@@ -135,7 +137,7 @@ inline int getHouseVisualHouse(int house) {
 inline int getHouseColorPaletteIndex(int house) {
     const int visualHouse = getHouseVisualHouse(house);
     if(isValidHouseColorSlot(visualHouse)) {
-        return houseColorToPaletteIndex[visualHouse];
+        return visualHouse == HOUSE_CUSTOM ? getHousePaletteIndex(HOUSE_CUSTOM) : houseColorToPaletteIndex[visualHouse];
     }
 
     return PALCOLOR_HARKONNEN;
@@ -143,7 +145,7 @@ inline int getHouseColorPaletteIndex(int house) {
 
 inline int getHouseColorPaletteIndexFromSlot(int colorSlot) {
     if(isValidHouseColorSlot(colorSlot)) {
-        return houseColorToPaletteIndex[colorSlot];
+        return colorSlot == HOUSE_CUSTOM ? getHousePaletteIndex(HOUSE_CUSTOM) : houseColorToPaletteIndex[colorSlot];
     }
 
     return PALCOLOR_HARKONNEN;
@@ -169,6 +171,12 @@ inline Uint32 getHouseColorRGB(int colorSlot, int shadeOffset = 3) {
 
 void loadCustomPalette();
 void applyCustomPaletteRuntimeHouseRamps();
+bool isHouseAvailable(HOUSETYPE house);
+int getNumAvailableHouses();
+char getHouseScenarioLetter(HOUSETYPE house);
+std::string getHouseRegionPrefix(HOUSETYPE house);
+HOUSETYPE getHouseFallbackHouse(HOUSETYPE house);
+
 void resetHouseVisualHouseMapping();
 void setHouseVisualHouse(HOUSETYPE house, int visualHouse);
 

--- a/include/mod/CustomHouseConfig.h
+++ b/include/mod/CustomHouseConfig.h
@@ -1,0 +1,33 @@
+#ifndef CUSTOMHOUSECONFIG_H
+#define CUSTOMHOUSECONFIG_H
+
+#include <charconv>
+#include <string>
+#include <system_error>
+
+namespace CustomHouseConfig {
+
+/**
+ * Parse a complete base-10 integer without throwing.
+ * The destination is left unchanged when parsing fails.
+ */
+inline bool parseInteger(const std::string& text, int& destination) noexcept {
+    if(text.empty()) {
+        return false;
+    }
+
+    int parsedValue = 0;
+    const char* const begin = text.data();
+    const char* const end = begin + text.size();
+    const auto result = std::from_chars(begin, end, parsedValue, 10);
+    if(result.ec != std::errc{} || result.ptr != end) {
+        return false;
+    }
+
+    destination = parsedValue;
+    return true;
+}
+
+} // namespace CustomHouseConfig
+
+#endif // CUSTOMHOUSECONFIG_H

--- a/include/mod/ModInfo.h
+++ b/include/mod/ModInfo.h
@@ -21,6 +21,19 @@
 #include <string>
 
 /**
+ * Optional registration for the fixed generic ninth-house slot.
+ * Content remains entirely mod-owned.
+ */
+struct CustomHouseInfo {
+    bool enabled = false;
+    std::string displayName;
+    char scenarioLetter = '?';
+    std::string regionPrefix;
+    int paletteIndex = 0;
+    int fallbackHouse = 0;
+};
+
+/**
  * Checksums for mod verification in multiplayer.
  * Each hash is a 16-character hex string (FNV-1a).
  */
@@ -28,7 +41,8 @@ struct ModChecksums {
     std::string objectData;      ///< Hash of ObjectData (unit/structure stats)
     std::string quantBotConfig;  ///< Hash of QuantBot AI config
     std::string gameOptions;     ///< Hash of game options/rules
-    std::string combined;        ///< Combined hash of all three
+    std::string customHouse;     ///< Hash of optional CustomHouse.ini registration
+    std::string combined;        ///< Combined hash of all synchronized configuration
     
     bool operator==(const ModChecksums& other) const {
         return combined == other.combined;
@@ -50,6 +64,7 @@ struct ModInfo {
     std::string version;         ///< Mod version (user-defined, e.g., "1.0.0")
     std::string gameVersion;     ///< Game version this mod was created for
     ModChecksums checksums;      ///< Cached checksums
+    CustomHouseInfo customHouse; ///< Optional generic ninth-house registration
     
     bool hasObjectData;          ///< Does this mod have ObjectData.ini?
     bool hasQuantBotConfig;      ///< Does this mod have QuantBot Config.ini?

--- a/include/mod/ModManager.h
+++ b/include/mod/ModManager.h
@@ -67,6 +67,8 @@ public:
      * \return Mod name (e.g., "vanilla")
      */
     std::string getActiveModName() const;
+    const CustomHouseInfo& getActiveCustomHouseInfo() const;
+    bool isCustomHouseRegistered() const;
 
     /**
      * \return true if the active mod opts into DuneCity city-sim features
@@ -266,7 +268,8 @@ private:
     bool installedObjectDataDiffersFromDefaults(const std::string& modName) const;
     
     std::string modsBasePath;        ///< Base path for mods directory
-    std::string activeMod;           ///< Currently active mod name
+    std::string activeMod;
+    CustomHouseInfo activeCustomHouse;           ///< Currently active mod name
     mutable ModChecksums cachedChecksums;  ///< Cached checksums
     mutable bool checksumsDirty;     ///< Do checksums need recalculation?
     bool initialized;                ///< Has initialize() been called?

--- a/src/CutScenes/Finale.cpp
+++ b/src/CutScenes/Finale.cpp
@@ -77,7 +77,7 @@ Finale::Finale(int house) {
     if(pPlanetDuneInHouseColorSurface == nullptr) {
         THROW(std::runtime_error, "Finale::Finale(): Cannot open MAPPLAN.CPS!");
     }
-    pPlanetDuneInHouseColorSurface = mapSurfaceColorRange(pPlanetDuneInHouseColorSurface.get(), houseToPaletteIndex[HOUSE_HARKONNEN], houseToPaletteIndex[house]);
+    pPlanetDuneInHouseColorSurface = mapSurfaceColorRange(pPlanetDuneInHouseColorSurface.get(), houseToPaletteIndex[HOUSE_HARKONNEN], getHousePaletteIndex(static_cast<HOUSETYPE>(house)));
 
     if(house == HOUSE_HARKONNEN || house == HOUSE_ATREIDES || house == HOUSE_ORDOS) {
         lizard = getChunkFromFile("LIZARD1.VOC");
@@ -89,7 +89,7 @@ Finale::Finale(int house) {
 
     const auto pIntroText = std::make_unique<IndexedTextFile>(pFileManager->openFile("INTRO." + _("LanguageFileExtension")).get());
 
-    const Uint32 color = SDL2RGB(palette[houseToPaletteIndex[house]+1]);
+    const Uint32 color = SDL2RGB(palette[getHousePaletteIndex(static_cast<HOUSETYPE>(house))+1]);
     const Uint32 sardaukarColor = SDL2RGB(palette[PALCOLOR_SARDAUKAR+1]);
 
     switch(house) {

--- a/src/CutScenes/Meanwhile.cpp
+++ b/src/CutScenes/Meanwhile.cpp
@@ -54,9 +54,9 @@ Meanwhile::Meanwhile(int house, bool firstMeanwhile) {
     }
 
     int houseOfVisitor = (house+2)%3;
-    Uint32 color = SDL2RGB(palette[houseToPaletteIndex[house]+1]);
+    Uint32 color = SDL2RGB(palette[getHousePaletteIndex(static_cast<HOUSETYPE>(house))+1]);
     Uint32 sardaukarColor = SDL2RGB(palette[PALCOLOR_SARDAUKAR+1]);
-    Uint32 visitorColor = SDL2RGB(palette[houseToPaletteIndex[houseOfVisitor]+1]);
+    Uint32 visitorColor = SDL2RGB(palette[getHousePaletteIndex(static_cast<HOUSETYPE>(houseOfVisitor))+1]);
 
     if(firstMeanwhile == true) {
         // Meanwhile after level 4

--- a/src/FileClasses/GFXManager.cpp
+++ b/src/FileClasses/GFXManager.cpp
@@ -2772,7 +2772,7 @@ GFXManager::GFXManager() {
                     uiGraphic[UI_Herald_Colored][house] = copySurface(fallback);
                 } else {
                     uiGraphic[UI_Herald_Colored][house] =
-                        mapSurfaceColorRange(fallback, PALCOLOR_HARKONNEN, houseToPaletteIndex[house]);
+                        mapSurfaceColorRange(fallback, PALCOLOR_HARKONNEN, getHousePaletteIndex(static_cast<HOUSETYPE>(house)));
                 }
             }
 

--- a/src/FileClasses/SFXManager.cpp
+++ b/src/FileClasses/SFXManager.cpp
@@ -95,7 +95,8 @@ void SFXManager::loadEnglishVoice() {
 
         std::string HouseString;
         const int VoiceNum = house;
-        switch(house) {
+        const HOUSETYPE contentHouse = getHouseFallbackHouse(static_cast<HOUSETYPE>(house));
+        switch(contentHouse) {
             case HOUSE_HARKONNEN:
                 HouseString = "H";
                 HouseNameChunk = getChunkFromFile("HHARK.VOC", "HARK.VOC");

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -3437,6 +3437,9 @@ bool Game::loadSaveGame(InputStream& stream) {
     // read gameInitSettings
     logLoadStage("game settings");
     gameInitSettings = GameInitSettings(stream);
+    if(savegameVersion <= 9820) {
+        gameInitSettings.migrateLegacyHouseColorSlots();
+    }
 
     // read the actual house setup choosen at the beginning of the game
     logLoadStage("house setup");
@@ -3454,7 +3457,10 @@ bool Game::loadSaveGame(InputStream& stream) {
 
         const Uint32 numHouseColors = stream.readUint32();
         for(Uint32 i=0; i<numHouseColors; i++) {
-            const int colorOfHouse = stream.readSint32();
+            int colorOfHouse = stream.readSint32();
+            if(savegameVersion <= 9820) {
+                colorOfHouse = migrateLegacyHouseColorSlot(colorOfHouse);
+            }
             if(i < houseInfoListSetup.size()) {
                 houseInfoListSetup[i].colorOfHouse = colorOfHouse;
             }
@@ -3503,16 +3509,17 @@ bool Game::loadSaveGame(InputStream& stream) {
     //   "dunelegacy*"               → 41 items (original Dune Legacy 0.99.x)
     //   "dunecity1.0.0"–"1.0.7"    → 48 items
     //   "dunecity1.0.8"–"1.0.10"   → 52 items
+    const int savedHouseCount = (savegameVersion >= 9821) ? NUM_HOUSES : NUM_LEGACY_HOUSES;
     int savedItemCount = determineLegacySavedItemCount(savegameVersion, duneVersion);
     if(savedItemCount != 0) {
         SDL_Log("Game::loadSaveGame(): legacy save v%d (%s) — loading %d items (current: %d)",
                 savegameVersion, duneVersion.c_str(), savedItemCount, Num_ItemID);
     }
-    objectData.load(stream, savedItemCount);
+    objectData.load(stream, savedItemCount, savedHouseCount);
 
     //load the house(s) info
     logLoadStage("houses and players");
-    for(int i=0; i<NUM_HOUSES; i++) {
+    for(int i=0; i<savedHouseCount; i++) {
         if (stream.readBool() == true) {
             //house in game
             house[i] = std::make_unique<House>(stream);

--- a/src/GameInitSettings.cpp
+++ b/src/GameInitSettings.cpp
@@ -202,8 +202,14 @@ void GameInitSettings::save(OutputStream& stream) const {
 
 
 
+void GameInitSettings::migrateLegacyHouseColorSlots() {
+    for(HouseInfo& houseInfo : houseInfoList) {
+        houseInfo.colorOfHouse = migrateLegacyHouseColorSlot(houseInfo.colorOfHouse);
+    }
+}
+
 std::string GameInitSettings::getScenarioFilename(HOUSETYPE newHouse, int mission) {
-    if( (newHouse < 0) || (newHouse >= NUM_HOUSES)) {
+    if((newHouse < 0) || (newHouse >= NUM_HOUSES) || !isHouseAvailable(newHouse)) {
         THROW(std::invalid_argument, "GameInitSettings::getScenarioFilename(): Invalid house id " + std::to_string(newHouse) + ".");
     }
 
@@ -212,7 +218,7 @@ std::string GameInitSettings::getScenarioFilename(HOUSETYPE newHouse, int missio
     }
 
     std::string name = "SCEN?0??.INI";
-    name[4] = houseChar[newHouse];
+    name[4] = getHouseScenarioLetter(newHouse);
 
     name[6] = '0' + (mission / 10);
     name[7] = '0' + (mission % 10);

--- a/src/INIMap/INIMapEditorLoader.cpp
+++ b/src/INIMap/INIMapEditorLoader.cpp
@@ -307,6 +307,7 @@ void INIMapEditorLoader::loadMap() {
 void INIMapEditorLoader::loadHouses()
 {
     for(int houseID = 0; houseID < NUM_HOUSES; houseID++) {
+        if(!isHouseAvailable(static_cast<HOUSETYPE>(houseID))) continue;
         std::string houseName = getHouseNameByNumber((HOUSETYPE) houseID);
 
         if(inifile->hasSection(houseName)) {
@@ -325,10 +326,11 @@ void INIMapEditorLoader::loadHouses()
         }
     }
 
-    for(int i=1;i<=NUM_HOUSES;i++) {
+    for(int i=1;i<=getNumAvailableHouses();i++) {
         std::string sectionname = "player" + std::to_string(i);
         if(inifile->hasSection(sectionname)) {
             for(int houseID = 0; houseID < NUM_HOUSES; houseID++) {
+                if(!isHouseAvailable(static_cast<HOUSETYPE>(houseID))) continue;
                 MapEditor::Player& player = pMapEditor->getPlayers()[houseID];
 
                 if(player.bActive == false) {

--- a/src/INIMap/INIMapLoader.cpp
+++ b/src/INIMap/INIMapLoader.cpp
@@ -43,7 +43,7 @@ int chooseSpecialVehicle(Game* pGame, int houseID) {
 
     const bool tornieActive = ModManager::instance().isInitialized()
         && ModManager::instance().getActiveModName() == "Tornie";
-    const auto pool = getSpecialVehiclePoolForHouse(houseID, tornieActive);
+    const auto pool = getSpecialVehiclePoolForHouse(getHouseFallbackHouse(static_cast<HOUSETYPE>(houseID)), tornieActive);
 
     std::vector<int> enabledPool;
     enabledPool.reserve(pool.size());
@@ -423,7 +423,7 @@ void INIMapLoader::loadHouses()
 
     // find "player?" sections
     std::vector<std::string> playerSectionsOnMap;
-    for(int i=1;i<=NUM_HOUSES;i++) {
+    for(int i=1;i<=getNumAvailableHouses();i++) {
         std::string sectionname = "player" + std::to_string(i);
         if(inifile->hasSection(sectionname)) {
             playerSectionsOnMap.push_back(sectionname);
@@ -434,6 +434,7 @@ void INIMapLoader::loadHouses()
     std::vector<HOUSETYPE> unboundedHouses;
 
     for(int h=0;h<NUM_HOUSES;h++) {
+        if(!isHouseAvailable(static_cast<HOUSETYPE>(h))) continue;
         bool bFound = false;
         for(const GameInitSettings::HouseInfo& houseInfo : houseInfoList) {
             if(houseInfo.houseID == (HOUSETYPE) h) {
@@ -450,6 +451,7 @@ void INIMapLoader::loadHouses()
 
     // init housename2house mapping with every house section marked as unused
     for(int i=0;i<NUM_HOUSES;i++) {
+        if(!isHouseAvailable(static_cast<HOUSETYPE>(i))) continue;
         std::string houseName = getHouseNameByNumber((HOUSETYPE) i);
         convertToLower(houseName);
 

--- a/src/MapEditor/MapEditor.cpp
+++ b/src/MapEditor/MapEditor.cpp
@@ -676,7 +676,7 @@ void MapEditor::saveMap(const std::string& filepath) {
     }
 
 
-    for(int i=1;i<=NUM_HOUSES;i++) {
+    for(int i=1;i<=getNumAvailableHouses();i++) {
         loadedINIFile->removeSection("player" + std::to_string(i));
     }
 
@@ -723,7 +723,7 @@ void MapEditor::saveMap(const std::string& filepath) {
     }
 
     // remove players that are leftovers
-    for(int i=currentAnyHouseNumber;i<NUM_HOUSES;i++) {
+    for(int i=currentAnyHouseNumber;i<getNumAvailableHouses();i++) {
         loadedINIFile->removeSection("Player" + std::to_string(i));
     }
 
@@ -909,8 +909,8 @@ void MapEditor::performMapEdit(int xpos, int ypos, bool bRepeated) {
                 for(int i=0;i<mapMirror->getSize();i++) {
 
                     int nextHouse = HOUSE_INVALID;
-                    for(int k = currentHouse; k < currentHouse+NUM_HOUSES;k++) {
-                        if(players[k%NUM_HOUSES].bActive == bHouseIsActive) {
+                    for(int k = currentHouse; k < currentHouse+getNumAvailableHouses();k++) {
+                        if(players[k%getNumAvailableHouses()].bActive == bHouseIsActive) {
                             nextHouse = k;
                             break;
                         }
@@ -919,7 +919,7 @@ void MapEditor::performMapEdit(int xpos, int ypos, bool bRepeated) {
                     if(nextHouse != HOUSE_INVALID) {
                         Coord position = mapMirror->getCoord( Coord(xpos, ypos), i, structureSize);
 
-                        MapEditorStructurePlaceOperation placeOperation(position, (HOUSETYPE) (nextHouse%NUM_HOUSES), currentEditorMode.itemID, currentEditorMode.health);
+                        MapEditorStructurePlaceOperation placeOperation(position, (HOUSETYPE) (nextHouse%getNumAvailableHouses()), currentEditorMode.itemID, currentEditorMode.health);
 
                         addUndoOperation(placeOperation.perform(this));
 
@@ -951,8 +951,8 @@ void MapEditor::performMapEdit(int xpos, int ypos, bool bRepeated) {
                 for(int i=0;i<mapMirror->getSize();i++) {
 
                     int nextHouse = HOUSE_INVALID;
-                    for(int k = currentHouse; k < currentHouse+NUM_HOUSES;k++) {
-                        if(players[k%NUM_HOUSES].bActive == bHouseIsActive) {
+                    for(int k = currentHouse; k < currentHouse+getNumAvailableHouses();k++) {
+                        if(players[k%getNumAvailableHouses()].bActive == bHouseIsActive) {
                             nextHouse = k;
                             break;
                         }
@@ -963,7 +963,7 @@ void MapEditor::performMapEdit(int xpos, int ypos, bool bRepeated) {
 
                         int angle =  mapMirror->getAngle(currentEditorMode.angle, i);
 
-                        MapEditorUnitPlaceOperation placeOperation(position, (HOUSETYPE) (nextHouse%NUM_HOUSES), currentEditorMode.itemID, currentEditorMode.health, angle, currentEditorMode.attackmode);
+                        MapEditorUnitPlaceOperation placeOperation(position, (HOUSETYPE) (nextHouse%getNumAvailableHouses()), currentEditorMode.itemID, currentEditorMode.health, angle, currentEditorMode.attackmode);
 
                         addUndoOperation(placeOperation.perform(this));
                         currentHouse = nextHouse + 1;

--- a/src/MapEditor/PlayerSettingsWindow.cpp
+++ b/src/MapEditor/PlayerSettingsWindow.cpp
@@ -57,7 +57,7 @@ PlayerSettingsWindow::PlayerSettingsWindow(MapEditor* pMapEditor, HOUSETYPE curr
 
     mainVBox.addWidget(&centralVBox, 360);
 
-    for(int i=0;i<NUM_HOUSES;i++) {
+    for(int i=0;i<getNumAvailableHouses();i++) {
 
         MapEditor::Player& playerInfo = pMapEditor->getPlayers()[i];
 
@@ -120,11 +120,11 @@ PlayerSettingsWindow::PlayerSettingsWindow(MapEditor* pMapEditor, HOUSETYPE curr
                 playerWidgets[i].teamDropDownBox.setSelectedItem(1);
             }
         } else {
-            for(int team = 0; team < NUM_HOUSES; team++) {
+            for(int team = 0; team < getNumAvailableHouses(); team++) {
                 playerWidgets[i].teamDropDownBox.addEntry("Team" + std::to_string(team + 1), team);
             }
 
-            for(int j = 0; j < NUM_HOUSES; j++) {
+            for(int j = 0; j < getNumAvailableHouses(); j++) {
                 if(playerWidgets[i].teamDropDownBox.getEntry(j) == playerInfo.brain) {
                     playerWidgets[i].teamDropDownBox.setSelectedItem(j);
                     break;
@@ -202,7 +202,7 @@ void PlayerSettingsWindow::onAdvancedBasicToggle() {
     if(advancedBasicToggle.getText() == _("Advanced...")) {
         advancedBasicToggle.setText(_("Basic..."));
 
-        for(int i=0;i<NUM_HOUSES;i++) {
+        for(int i=0;i<getNumAvailableHouses();i++) {
             playerWidgets[i].playerHBox.removeChildWidget(&playerWidgets[i].creditsLabel);
             playerWidgets[i].playerHBox.removeChildWidget(&playerWidgets[i].creditsTextBox);
             playerWidgets[i].playerHBox.removeChildWidget(&playerWidgets[i].spacer);
@@ -220,7 +220,7 @@ void PlayerSettingsWindow::onAdvancedBasicToggle() {
     } else {
         advancedBasicToggle.setText(_("Advanced..."));
 
-        for(int i=0;i<NUM_HOUSES;i++) {
+        for(int i=0;i<getNumAvailableHouses();i++) {
             playerWidgets[i].playerHBox.removeChildWidget(&playerWidgets[i].spiceQuotaLabel);
             playerWidgets[i].playerHBox.removeChildWidget(&playerWidgets[i].spiceQuotaTextBox);
             playerWidgets[i].playerHBox.removeChildWidget(&playerWidgets[i].spacer);
@@ -241,7 +241,7 @@ void PlayerSettingsWindow::onOK() {
 
     pMapEditor->startOperation();
 
-    for(int i=0;i<NUM_HOUSES;i++) {
+    for(int i=0;i<getNumAvailableHouses();i++) {
         bool bActive = playerWidgets[i].playerCheckbox.isChecked();
         bool bAnyHouse = pMapEditor->getMapVersion() < 2 ? false : playerWidgets[i].anyHouseRadioButton.isChecked();
         int credits = playerWidgets[i].creditsTextBox.getValue();

--- a/src/Menu/CustomGamePlayers.cpp
+++ b/src/Menu/CustomGamePlayers.cpp
@@ -41,6 +41,7 @@
 #include <misc/IMemoryStream.h>
 
 #include <INIMap/INIMapPreviewCreator.h>
+#include <INIMap/MapPlayerSectionUtils.h>
 
 #include <misc/DiscordManager.h>
 
@@ -1487,12 +1488,13 @@ void CustomGamePlayers::extractMapInfo(INIFile* pMap)
         }
     }
 
-    numHouses = boundHousesOnMap.size();
-    for(int p = 1; p <= numHouses; p++) {
-        if(pMap->hasSection("Player" + std::to_string(p))) {
-            numHouses++;
-        }
-    }
+    const int boundHouseCount = static_cast<int>(boundHousesOnMap.size());
+    const int numberedPlayerCount = MapPlayerSectionUtils::countNumberedPlayerSections(
+        getNumAvailableHouses(),
+        [&pMap](int playerNumber) {
+            return pMap->hasSection("Player" + std::to_string(playerNumber));
+        });
+    numHouses = boundHouseCount + numberedPlayerCount;
 
     mapPropertyPlayers.setText(std::to_string(numHouses));
 

--- a/src/Menu/CustomGamePlayers.cpp
+++ b/src/Menu/CustomGamePlayers.cpp
@@ -86,7 +86,7 @@ void addColorDropDownEntries(DropDownBox& colorDropDown, int selectedColor, bool
             colorDropDown.addEntry(getCustomColorName(h), h);
         }
     } else {
-        for(int h = 0; h < NUM_HOUSES; h++) {
+        for(int h = 0; h < getNumAvailableHouses(); h++) {
             colorDropDown.addEntry(getHouseNameByNumber(static_cast<HOUSETYPE>(h)), h);
         }
     }
@@ -275,7 +275,7 @@ CustomGamePlayers::CustomGamePlayers(const GameInitSettings& newGameInitSettings
 
     bool thisPlayerPlaced = false;
 
-    for(int i=0;i<NUM_HOUSES;i++) {
+    for(int i=0;i<numHouses;i++) {
         HouseInfo& curHouseInfo = houseInfo[i];
 
         // set up header row with Label "House", DropDown for house selection and DropDown for team selection
@@ -317,7 +317,7 @@ CustomGamePlayers::CustomGamePlayers(const GameInitSettings& newGameInitSettings
             curHouseInfo.teamDropDown.setEnabled(false);
             curHouseInfo.teamDropDown.setOnClickEnabled(false);
         } else {
-            for(int team = 0 ; team < NUM_TEAMS ; team++) {
+            for(int team = 0 ; team < getNumAvailableHouses() ; team++) {
                 curHouseInfo.teamDropDown.addEntry(_("Team") + " " + std::to_string(team+1), team+1);
             }
             curHouseInfo.teamDropDown.setSelectedItem(slotToTeam[i]);
@@ -729,7 +729,7 @@ ChangeEventList CustomGamePlayers::getChangeEventList()
 {
     ChangeEventList changeEventList;
 
-    for(int i=0;i<NUM_HOUSES;i++) {
+    for(int i=0;i<numHouses;i++) {
         HouseInfo& curHouseInfo = houseInfo[i];
 
         int houseID = curHouseInfo.houseDropDown.getSelectedEntryIntData();
@@ -1129,7 +1129,7 @@ void CustomGamePlayers::updateDiscordGameStarting() {
     std::string playerDetails;
     int playerCount = 0;
     
-    for(int i = 0; i < NUM_HOUSES; i++) {
+    for(int i = 0; i < numHouses; i++) {
         HouseInfo& curHouseInfo = houseInfo[i];
         
         int houseID = curHouseInfo.houseDropDown.getSelectedEntryIntData();
@@ -1205,7 +1205,7 @@ void CustomGamePlayers::onNext()
     bool bDuplicateHouse = false;
     bool bDuplicateColor = false;
 
-    for(int i=0;i<NUM_HOUSES;i++) {
+    for(int i=0;i<numHouses;i++) {
         HouseInfo& curHouseInfo = houseInfo[i];
 
         int currentPlayer1 = curHouseInfo.player1DropDown.getSelectedEntryIntData();
@@ -1222,7 +1222,7 @@ void CustomGamePlayers::onNext()
             }
 
             const int selectedHouse = curHouseInfo.houseDropDown.getSelectedEntryIntData();
-            if(selectedHouse >= 0 && selectedHouse < NUM_HOUSES) {
+            if(selectedHouse >= 0 && isHouseAvailable(static_cast<HOUSETYPE>(selectedHouse))) {
                 if(houseAlreadyUsed[selectedHouse]) {
                     bDuplicateHouse = true;
                 } else {
@@ -1329,7 +1329,7 @@ void CustomGamePlayers::addAllPlayersToGameInitSettings()
 {
     gameInitSettings.clearHouseInfo();
 
-    for(int i=0;i<NUM_HOUSES;i++) {
+    for(int i=0;i<numHouses;i++) {
         HouseInfo& curHouseInfo = houseInfo[i];
 
         int houseID = curHouseInfo.houseDropDown.getSelectedEntryIntData();
@@ -1480,7 +1480,7 @@ void CustomGamePlayers::extractMapInfo(INIFile* pMap)
 
 
     boundHousesOnMap.clear();
-    for(int h = 0; h < NUM_HOUSES; h++) {
+    for(int h = 0; h < getNumAvailableHouses(); h++) {
         const HOUSETYPE house = static_cast<HOUSETYPE>(h);
         if(pMap->hasSection(getHouseNameByNumber(house))) {
             boundHousesOnMap.push_back(house);
@@ -1488,7 +1488,7 @@ void CustomGamePlayers::extractMapInfo(INIFile* pMap)
     }
 
     numHouses = boundHousesOnMap.size();
-    for(int p = 1; p <= NUM_HOUSES; p++) {
+    for(int p = 1; p <= numHouses; p++) {
         if(pMap->hasSection("Player" + std::to_string(p))) {
             numHouses++;
         }
@@ -1535,7 +1535,7 @@ void CustomGamePlayers::extractMapInfo(INIFile* pMap)
         currentIndex++;
     }
 
-    for(int p = 0; (p < NUM_HOUSES) && (currentIndex < NUM_HOUSES); p++) {
+    for(int p = 0; (p < numHouses) && (currentIndex < numHouses); p++) {
         if(pMap->hasSection("Player" + std::to_string(p+1))) {
             std::string teamName = strToUpper(pMap->getStringValue("Player" + std::to_string(p+1),"Brain","Team " + std::to_string(currentIndex+p+1)));
             teamNames.push_back(teamName);
@@ -1555,7 +1555,7 @@ void CustomGamePlayers::extractMapInfo(INIFile* pMap)
         }
     }
 
-    for(;currentIndex < NUM_HOUSES; currentIndex++) {
+    for(;currentIndex < numHouses; currentIndex++) {
         slotToTeam[currentIndex] = -1;
     }
 }
@@ -1619,7 +1619,7 @@ void CustomGamePlayers::onChangeHousesDropDownBoxes(bool bInteractive, int house
 
         addToHouseDropDown(curHouseInfo.houseDropDown, HOUSE_INVALID);
 
-        for(int h=0;h<NUM_HOUSES;h++) {
+        for(int h=0;h<getNumAvailableHouses();h++) {
             bool bAddHouse;
 
             bool bCheck;
@@ -1704,7 +1704,7 @@ void CustomGamePlayers::onChangeColorDropDownBoxes(bool bInteractive, int houseI
 }
 
 void CustomGamePlayers::onBonusColorCheckbox(int houseInfoNum) {
-    if(houseInfoNum < 0 || houseInfoNum >= NUM_HOUSES) {
+    if(houseInfoNum < 0 || houseInfoNum >= numHouses) {
         return;
     }
 
@@ -1998,7 +1998,7 @@ void CustomGamePlayers::addToHouseDropDown(DropDownBox& houseDropDownBox, int ho
 
             int currentItemIndex = (houseDropDownBox.getEntryIntData(0) == HOUSE_INVALID) ? 1 : 0;
 
-            for(int h = 0; h < NUM_HOUSES; h++) {
+            for(int h = 0; h < getNumAvailableHouses(); h++) {
                 if(currentItemIndex < houseDropDownBox.getNumEntries() && houseDropDownBox.getEntryIntData(currentItemIndex) == h) {
                     if(h == house) {
                         if(bSelect) {
@@ -2040,7 +2040,7 @@ bool CustomGamePlayers::isBoundedHouseOnMap(HOUSETYPE houseID) {
 }
 
 void CustomGamePlayers::disableAllDropDownBoxes() {
-    for(int i=0;i<NUM_HOUSES;i++) {
+    for(int i=0;i<numHouses;i++) {
         HouseInfo& curHouseInfo = houseInfo[i];
 
         curHouseInfo.houseDropDown.setEnabled(false);

--- a/src/Menu/HouseChoiceInfoMenu.cpp
+++ b/src/Menu/HouseChoiceInfoMenu.cpp
@@ -31,8 +31,9 @@ HouseChoiceInfoMenu::HouseChoiceInfoMenu(int newHouse) : MentatMenu(HOUSE_INVALI
     house = newHouse;
 
     Animation* anim = nullptr;
+    const HOUSETYPE displayHouse = getHouseFallbackHouse(static_cast<HOUSETYPE>(house));
 
-    switch(house) {
+    switch(displayHouse) {
         case HOUSE_HARKONNEN:   anim = pGFXManager->getAnimation(Anim_HarkonnenPlanet); break;
         case HOUSE_ATREIDES:    anim = pGFXManager->getAnimation(Anim_AtreidesPlanet);  break;
         case HOUSE_ORDOS:       anim = pGFXManager->getAnimation(Anim_OrdosPlanet);     break;

--- a/src/Menu/HouseChoiceMenu.cpp
+++ b/src/Menu/HouseChoiceMenu.cpp
@@ -36,12 +36,19 @@ const int houseOrder[] = {
     HOUSE_FREMEN,
     HOUSE_SARDAUKAR,
     HOUSE_NEUTRAL,
-    HOUSE_REBELS
+    HOUSE_REBELS,
+    HOUSE_CUSTOM
 };
 
 constexpr int kVisibleHouseButtons = 3;
-constexpr int kHouseChoiceCount = sizeof(houseOrder) / sizeof(houseOrder[0]);
-constexpr int kMaxHouseScrollPos = kHouseChoiceCount - kVisibleHouseButtons;
+int getHouseChoiceCount() {
+    const int capacity = sizeof(houseOrder) / sizeof(houseOrder[0]);
+    return isHouseAvailable(HOUSE_CUSTOM) ? capacity : capacity - 1;
+}
+
+int getMaxHouseScrollPos() {
+    return getHouseChoiceCount() - kVisibleHouseButtons;
+}
 
 const char* const kSupportPlayerClasses[] = {
     "",
@@ -224,7 +231,7 @@ void HouseChoiceMenu::onHouseLeft()
 
 void HouseChoiceMenu::onHouseRight()
 {
-    if(currentHouseChoiceScrollPos < kMaxHouseScrollPos) {
+    if(currentHouseChoiceScrollPos < getMaxHouseScrollPos()) {
         currentHouseChoiceScrollPos++;
         updateHouseChoice();
     }

--- a/src/Menu/MapChoice.cpp
+++ b/src/Menu/MapChoice.cpp
@@ -366,7 +366,7 @@ void MapChoice::createMapSurfaceWithPieces(unsigned int scenario) {
 }
 
 void MapChoice::loadINI() {
-    const std::string filename = fmt::sprintf("REGION%c.INI", houseChar[house]);
+    const std::string filename = fmt::sprintf("REGION%c.INI", getHouseScenarioLetter(static_cast<HOUSETYPE>(house)));
 
     INIFile RegionINI(pFileManager->openCampaignFile(filename).get());
 
@@ -407,6 +407,7 @@ void MapChoice::loadINI() {
                 case HOUSE_MERCENARY:   key = "MER"; break;
                 case HOUSE_NEUTRAL:     key = "NEU"; break;
                 case HOUSE_REBELS:      key = "REB"; break;
+                case HOUSE_CUSTOM:      key = getHouseRegionPrefix(HOUSE_CUSTOM); break;
             }
 
             std::string strValue = RegionINI.getStringValue(strSection,key);

--- a/src/Menu/MentatHelp.cpp
+++ b/src/Menu/MentatHelp.cpp
@@ -34,7 +34,7 @@ MentatHelp::MentatHelp(int newHouse, int techLevel, int mission) : MentatMenu(ne
 
     mentatEntries = pTextManager->getAllMentatEntries(newHouse, techLevel);
 
-    Uint32 color = SDL2RGB(palette[houseToPaletteIndex[newHouse]+3]);
+    Uint32 color = SDL2RGB(palette[getHousePaletteIndex(static_cast<HOUSETYPE>(newHouse))+3]);
 
     if(mission == 0) {
         std::vector<MentatTextFile::MentatEntry>::iterator iter = mentatEntries.begin();

--- a/src/Menu/MultiPlayerMenu.cpp
+++ b/src/Menu/MultiPlayerMenu.cpp
@@ -596,6 +596,10 @@ void MultiPlayerMenu::showDisconnectMessageBox(int cause) {
             openWindow(MsgBox::create(_("There is no free player slot in this game left!")));
         } break;
 
+        case NETWORKDISCONNECT_PROTOCOL_MISMATCH: {
+            openWindow(MsgBox::create(_("The game host uses an incompatible network protocol version. Please use the same Dune City version.")));
+        } break;
+
         default: {
             openWindow(MsgBox::create(_("The connection to the game host was lost!")));
         } break;

--- a/src/Menu/SinglePlayerMenu.cpp
+++ b/src/Menu/SinglePlayerMenu.cpp
@@ -143,6 +143,9 @@ void SinglePlayerMenu::onCampaign() {
     }
 
     for(int houseID = 0; houseID < NUM_HOUSES; houseID++) {
+        if(!isHouseAvailable(static_cast<HOUSETYPE>(houseID))) {
+            continue;
+        }
         if(houseID == player) {
             GameInitSettings::HouseInfo humanHouseInfo((HOUSETYPE) player, 1);
             humanHouseInfo.addPlayerInfo( GameInitSettings::PlayerInfo(settings.general.playerName, HUMANPLAYERCLASS) );

--- a/src/Menu/SinglePlayerSkirmishMenu.cpp
+++ b/src/Menu/SinglePlayerSkirmishMenu.cpp
@@ -36,12 +36,19 @@ const int houseOrder[] = {
     HOUSE_FREMEN,
     HOUSE_SARDAUKAR,
     HOUSE_NEUTRAL,
-    HOUSE_REBELS
+    HOUSE_REBELS,
+    HOUSE_CUSTOM
 };
 
 constexpr int kVisibleHouseButtons = 3;
-constexpr int kHouseChoiceCount = sizeof(houseOrder) / sizeof(houseOrder[0]);
-constexpr int kMaxHouseScrollPos = kHouseChoiceCount - kVisibleHouseButtons;
+int getHouseChoiceCount() {
+    const int capacity = sizeof(houseOrder) / sizeof(houseOrder[0]);
+    return isHouseAvailable(HOUSE_CUSTOM) ? capacity : capacity - 1;
+}
+
+int getMaxHouseScrollPos() {
+    return getHouseChoiceCount() - kVisibleHouseButtons;
+}
 
 const char* const kSupportPlayerClasses[] = {
     "",
@@ -266,6 +273,9 @@ void SinglePlayerSkirmishMenu::onStart()
     }
 
     for(int houseID = 0; houseID < NUM_HOUSES; houseID++) {
+        if(!isHouseAvailable(static_cast<HOUSETYPE>(houseID))) {
+            continue;
+        }
         if(houseID == houseChoice) {
             GameInitSettings::HouseInfo humanHouseInfo(static_cast<HOUSETYPE>(houseID), 1);
             humanHouseInfo.addPlayerInfo(GameInitSettings::PlayerInfo(settings.general.playerName, HUMANPLAYERCLASS));
@@ -324,14 +334,14 @@ void SinglePlayerSkirmishMenu::onHouseLeft()
 
 void SinglePlayerSkirmishMenu::onHouseRight()
 {
-    if(currentHouseChoiceScrollPos < kMaxHouseScrollPos) {
+    if(currentHouseChoiceScrollPos < getMaxHouseScrollPos()) {
         currentHouseChoiceScrollPos++;
         selectedButton--;
         onSelectHouseButton(selectedButton);
         updateHouseChoice();
 
         houseLeftButton.setVisible(true);
-        houseRightButton.setVisible( (currentHouseChoiceScrollPos < kMaxHouseScrollPos) );
+        houseRightButton.setVisible( (currentHouseChoiceScrollPos < getMaxHouseScrollPos()) );
     }
 }
 

--- a/src/Network/NetworkManager.cpp
+++ b/src/Network/NetworkManager.cpp
@@ -981,6 +981,14 @@ void NetworkManager::handlePacket(ENetPeer* peer, ENetPacketIStream& packetStrea
                     std::string localVersion = VERSIONSTRING;
                     std::string localQuantBotHash = getQuantBotConfig().getConfigHash();
                     std::string localObjectDataHash = getObjectDataHash();
+
+                    if(peerProtocolVersion != NETWORK_PROTOCOL_VERSION) {
+                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                                     "NetworkManager: rejecting incompatible protocol from %s (peer=%u, local=%u)",
+                                     peerData->name.c_str(), peerProtocolVersion, NETWORK_PROTOCOL_VERSION);
+                        enet_peer_disconnect_later(peer, NETWORKDISCONNECT_PROTOCOL_MISMATCH);
+                        break;
+                    }
                     
                     if(bIsServer) {
                         // Server: verify client matches server config

--- a/src/Network/NetworkManager.cpp
+++ b/src/Network/NetworkManager.cpp
@@ -982,11 +982,15 @@ void NetworkManager::handlePacket(ENetPeer* peer, ENetPacketIStream& packetStrea
                     std::string localQuantBotHash = getQuantBotConfig().getConfigHash();
                     std::string localObjectDataHash = getObjectDataHash();
 
-                    if(peerProtocolVersion != NETWORK_PROTOCOL_VERSION) {
+                    const bool protocolRejected = rejectIncompatibleNetworkProtocol(
+                        peerProtocolVersion,
+                        [peer](int cause) {
+                            enet_peer_disconnect_later(peer, static_cast<enet_uint32>(cause));
+                        });
+                    if(protocolRejected) {
                         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                                      "NetworkManager: rejecting incompatible protocol from %s (peer=%u, local=%u)",
                                      peerData->name.c_str(), peerProtocolVersion, NETWORK_PROTOCOL_VERSION);
-                        enet_peer_disconnect_later(peer, NETWORKDISCONNECT_PROTOCOL_MISMATCH);
                         break;
                     }
                     

--- a/src/ObjectBase.cpp
+++ b/src/ObjectBase.cpp
@@ -167,9 +167,12 @@ ObjectBase::ObjectBase(InputStream& stream) {
 
     // The packed save field contains 8 bits. Keep the ninth team-array slot
     // initialized instead of indexing past the old seven-element temporary.
-    std::array<bool, NUM_TEAMS> b{};
+    std::array<bool, NUM_TEAM_SLOTS> b{};
 
     stream.readBools(&b[0], &b[1], &b[2], &b[3], &b[4], &b[5], &b[6], &b[7]);
+    if(currentGame && currentGame->getLoadedSavegameVersion() >= 9821) {
+        stream.readBools(&b[8], &b[9]);
+    }
 
     for (decltype(visible.size()) i = 0; i < visible.size(); ++i)
         visible[i] = b[i];
@@ -237,6 +240,7 @@ void ObjectBase::save(OutputStream& stream) const {
     stream.writeUint32(attackMode);
 
     stream.writeBools(visible[0], visible[1], visible[2], visible[3], visible[4], visible[5], visible[6], visible[7]);
+    stream.writeBools(visible[8], visible[9]);
 }
 
 
@@ -369,7 +373,7 @@ void ObjectBase::setVisible(int teamID, bool status) {
             visible.set();
         else
             visible.reset();
-    } else if ((teamID >= 0) && (teamID < NUM_TEAMS)) {
+    } else if ((teamID >= 0) && (teamID < NUM_TEAM_SLOTS)) {
         visible[teamID] = status;
     }
 }
@@ -408,7 +412,7 @@ bool ObjectBase::isOnScreen() const {
 }
 
 bool ObjectBase::isVisible(int teamID) const {
-    if((teamID >= 0) && (teamID < NUM_TEAMS)) {
+    if((teamID >= 0) && (teamID < NUM_TEAM_SLOTS)) {
         return visible[teamID];
     } else {
         return false;

--- a/src/ObjectData.cpp
+++ b/src/ObjectData.cpp
@@ -200,45 +200,45 @@ void ObjectData::loadFromINIFile(const std::string& filename, bool preferUserCon
     // load default structure values
     ObjectDataStruct structureDefaultData[NUM_HOUSES];
     for(int h=0;h<NUM_HOUSES;h++) {
-        structureDefaultData[h].enabled = loadBoolValue(*objectDataFile, "default structure", "Enabled", houseChar[h]);
-        structureDefaultData[h].hitpoints = loadIntValue(*objectDataFile, "default structure", "HitPoints", houseChar[h]);
-        structureDefaultData[h].price = loadIntValue(*objectDataFile, "default structure", "Price", houseChar[h]);
-        structureDefaultData[h].power = loadIntValue(*objectDataFile, "default structure", "Power", houseChar[h]);
-        structureDefaultData[h].viewrange = loadIntValue(*objectDataFile, "default structure", "ViewRange", houseChar[h]);
-        structureDefaultData[h].capacity = loadIntValue(*objectDataFile, "default structure", "Capacity", houseChar[h]);
-        structureDefaultData[h].weapondamage = loadIntValue(*objectDataFile, "default structure", "WeaponDamage", houseChar[h]);
-        structureDefaultData[h].weaponrange = loadIntValue(*objectDataFile, "default structure", "WeaponRange", houseChar[h]);
-        structureDefaultData[h].weaponreloadtime = loadIntValue(*objectDataFile, "default structure", "WeaponReloadTime", houseChar[h]);
-        structureDefaultData[h].maxspeed = loadFixPointValue(*objectDataFile, "default structure", "MaxSpeed", houseChar[h]);
-        structureDefaultData[h].turnspeed = loadFixPointValue(*objectDataFile, "default structure", "TurnSpeed", houseChar[h]);
-        structureDefaultData[h].buildtime = loadIntValue(*objectDataFile, "default structure", "BuildTime", houseChar[h]);
-        structureDefaultData[h].infspawnprop = loadIntValue(*objectDataFile, "default structure", "InfSpawnProp", houseChar[h]);
-        structureDefaultData[h].builder = loadItemID(*objectDataFile, "default structure", "Builder", houseChar[h]);
-        structureDefaultData[h].prerequisiteStructuresSet = loadPrerequisiteStructuresSet(*objectDataFile, "default structure", "Prerequisite", houseChar[h]);
-        structureDefaultData[h].techLevel = loadIntValue(*objectDataFile, "default structure", "TechLevel", houseChar[h], -1);
-        structureDefaultData[h].upgradeLevel = loadIntValue(*objectDataFile, "default structure", "UpgradeLevel", houseChar[h]);
+        structureDefaultData[h].enabled = loadBoolValue(*objectDataFile, "default structure", "Enabled", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].hitpoints = loadIntValue(*objectDataFile, "default structure", "HitPoints", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].price = loadIntValue(*objectDataFile, "default structure", "Price", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].power = loadIntValue(*objectDataFile, "default structure", "Power", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].viewrange = loadIntValue(*objectDataFile, "default structure", "ViewRange", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].capacity = loadIntValue(*objectDataFile, "default structure", "Capacity", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].weapondamage = loadIntValue(*objectDataFile, "default structure", "WeaponDamage", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].weaponrange = loadIntValue(*objectDataFile, "default structure", "WeaponRange", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].weaponreloadtime = loadIntValue(*objectDataFile, "default structure", "WeaponReloadTime", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].maxspeed = loadFixPointValue(*objectDataFile, "default structure", "MaxSpeed", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].turnspeed = loadFixPointValue(*objectDataFile, "default structure", "TurnSpeed", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].buildtime = loadIntValue(*objectDataFile, "default structure", "BuildTime", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].infspawnprop = loadIntValue(*objectDataFile, "default structure", "InfSpawnProp", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].builder = loadItemID(*objectDataFile, "default structure", "Builder", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].prerequisiteStructuresSet = loadPrerequisiteStructuresSet(*objectDataFile, "default structure", "Prerequisite", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        structureDefaultData[h].techLevel = loadIntValue(*objectDataFile, "default structure", "TechLevel", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), -1);
+        structureDefaultData[h].upgradeLevel = loadIntValue(*objectDataFile, "default structure", "UpgradeLevel", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
     }
 
     // load default unit values
     ObjectDataStruct unitDefaultData[NUM_HOUSES];
     for(int h=0;h<NUM_HOUSES;h++) {
-        unitDefaultData[h].enabled = loadBoolValue(*objectDataFile, "default unit", "Enabled", houseChar[h]);
-        unitDefaultData[h].hitpoints = loadIntValue(*objectDataFile, "default unit", "HitPoints", houseChar[h]);
-        unitDefaultData[h].price = loadIntValue(*objectDataFile, "default unit", "Price", houseChar[h]);
-        unitDefaultData[h].power = loadIntValue(*objectDataFile, "default unit", "Power", houseChar[h]);
-        unitDefaultData[h].viewrange = loadIntValue(*objectDataFile, "default unit", "ViewRange", houseChar[h]);
-        unitDefaultData[h].capacity = loadIntValue(*objectDataFile, "default unit", "Capacity", houseChar[h]);
-        unitDefaultData[h].weapondamage = loadIntValue(*objectDataFile, "default unit", "WeaponDamage", houseChar[h]);
-        unitDefaultData[h].weaponrange = loadIntValue(*objectDataFile, "default unit", "WeaponRange", houseChar[h]);
-        unitDefaultData[h].weaponreloadtime = loadIntValue(*objectDataFile, "default unit", "WeaponReloadTime", houseChar[h]);
-        unitDefaultData[h].maxspeed = loadFixPointValue(*objectDataFile, "default unit", "MaxSpeed", houseChar[h]);
-        unitDefaultData[h].turnspeed = loadFixPointValue(*objectDataFile, "default unit", "TurnSpeed", houseChar[h]);
-        unitDefaultData[h].buildtime = loadIntValue(*objectDataFile, "default unit", "BuildTime", houseChar[h]);
-        unitDefaultData[h].infspawnprop = loadIntValue(*objectDataFile, "default unit", "InfSpawnProp", houseChar[h]);
-        unitDefaultData[h].builder = loadItemID(*objectDataFile, "default structure", "Builder", houseChar[h]);
-        unitDefaultData[h].prerequisiteStructuresSet = loadPrerequisiteStructuresSet(*objectDataFile, "default unit", "Prerequisite", houseChar[h]);
-        unitDefaultData[h].techLevel = loadIntValue(*objectDataFile, "default unit", "TechLevel", houseChar[h], -1);
-        unitDefaultData[h].upgradeLevel = loadIntValue(*objectDataFile, "default unit", "UpgradeLevel", houseChar[h]);
+        unitDefaultData[h].enabled = loadBoolValue(*objectDataFile, "default unit", "Enabled", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].hitpoints = loadIntValue(*objectDataFile, "default unit", "HitPoints", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].price = loadIntValue(*objectDataFile, "default unit", "Price", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].power = loadIntValue(*objectDataFile, "default unit", "Power", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].viewrange = loadIntValue(*objectDataFile, "default unit", "ViewRange", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].capacity = loadIntValue(*objectDataFile, "default unit", "Capacity", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].weapondamage = loadIntValue(*objectDataFile, "default unit", "WeaponDamage", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].weaponrange = loadIntValue(*objectDataFile, "default unit", "WeaponRange", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].weaponreloadtime = loadIntValue(*objectDataFile, "default unit", "WeaponReloadTime", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].maxspeed = loadFixPointValue(*objectDataFile, "default unit", "MaxSpeed", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].turnspeed = loadFixPointValue(*objectDataFile, "default unit", "TurnSpeed", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].buildtime = loadIntValue(*objectDataFile, "default unit", "BuildTime", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].infspawnprop = loadIntValue(*objectDataFile, "default unit", "InfSpawnProp", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].builder = loadItemID(*objectDataFile, "default structure", "Builder", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].prerequisiteStructuresSet = loadPrerequisiteStructuresSet(*objectDataFile, "default unit", "Prerequisite", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
+        unitDefaultData[h].techLevel = loadIntValue(*objectDataFile, "default unit", "TechLevel", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), -1);
+        unitDefaultData[h].upgradeLevel = loadIntValue(*objectDataFile, "default unit", "UpgradeLevel", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)));
     }
 
     // set default values
@@ -271,23 +271,23 @@ void ObjectData::loadFromINIFile(const std::string& filename, bool preferUserCon
 
             ObjectDataStruct& defaultData = isStructure(itemID) ? structureDefaultData[h] : unitDefaultData[h];
 
-            data[itemID][h].enabled = loadBoolValue(*objectDataFile, sectionName, "Enabled", houseChar[h], defaultData.enabled);
-            data[itemID][h].hitpoints = loadIntValue(*objectDataFile, sectionName, "HitPoints", houseChar[h], defaultData.hitpoints);
-            data[itemID][h].price = loadIntValue(*objectDataFile, sectionName, "Price", houseChar[h], defaultData.price);
-            data[itemID][h].power = loadIntValue(*objectDataFile, sectionName, "Power", houseChar[h], defaultData.power);
-            data[itemID][h].viewrange = loadIntValue(*objectDataFile, sectionName, "ViewRange", houseChar[h], defaultData.viewrange);
-            data[itemID][h].capacity = loadIntValue(*objectDataFile, sectionName, "Capacity", houseChar[h], defaultData.capacity);
-            data[itemID][h].weapondamage = loadIntValue(*objectDataFile, sectionName, "WeaponDamage", houseChar[h], defaultData.weapondamage);
-            data[itemID][h].weaponrange = loadIntValue(*objectDataFile, sectionName, "WeaponRange", houseChar[h], defaultData.weaponrange);
-            data[itemID][h].weaponreloadtime = loadIntValue(*objectDataFile, sectionName, "WeaponReloadTime", houseChar[h], defaultData.weaponreloadtime);
-            data[itemID][h].maxspeed = loadFixPointValue(*objectDataFile, sectionName, "MaxSpeed", houseChar[h], defaultData.maxspeed);
-            data[itemID][h].turnspeed = loadFixPointValue(*objectDataFile, sectionName, "TurnSpeed", houseChar[h], defaultData.turnspeed);
-            data[itemID][h].buildtime = loadIntValue(*objectDataFile, sectionName, "BuildTime", houseChar[h], defaultData.buildtime);
-            data[itemID][h].infspawnprop = loadIntValue(*objectDataFile, sectionName, "InfSpawnProp", houseChar[h], defaultData.infspawnprop);
-            data[itemID][h].builder = loadItemID(*objectDataFile, sectionName, "Builder", houseChar[h], defaultData.builder);
-            data[itemID][h].prerequisiteStructuresSet = loadPrerequisiteStructuresSet(*objectDataFile, sectionName, "Prerequisite", houseChar[h], defaultData.prerequisiteStructuresSet);
-            data[itemID][h].techLevel = loadIntValue(*objectDataFile, sectionName, "TechLevel", houseChar[h], defaultData.techLevel);
-            data[itemID][h].upgradeLevel = loadIntValue(*objectDataFile, sectionName, "UpgradeLevel", houseChar[h], defaultData.upgradeLevel);
+            data[itemID][h].enabled = loadBoolValue(*objectDataFile, sectionName, "Enabled", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.enabled);
+            data[itemID][h].hitpoints = loadIntValue(*objectDataFile, sectionName, "HitPoints", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.hitpoints);
+            data[itemID][h].price = loadIntValue(*objectDataFile, sectionName, "Price", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.price);
+            data[itemID][h].power = loadIntValue(*objectDataFile, sectionName, "Power", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.power);
+            data[itemID][h].viewrange = loadIntValue(*objectDataFile, sectionName, "ViewRange", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.viewrange);
+            data[itemID][h].capacity = loadIntValue(*objectDataFile, sectionName, "Capacity", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.capacity);
+            data[itemID][h].weapondamage = loadIntValue(*objectDataFile, sectionName, "WeaponDamage", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.weapondamage);
+            data[itemID][h].weaponrange = loadIntValue(*objectDataFile, sectionName, "WeaponRange", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.weaponrange);
+            data[itemID][h].weaponreloadtime = loadIntValue(*objectDataFile, sectionName, "WeaponReloadTime", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.weaponreloadtime);
+            data[itemID][h].maxspeed = loadFixPointValue(*objectDataFile, sectionName, "MaxSpeed", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.maxspeed);
+            data[itemID][h].turnspeed = loadFixPointValue(*objectDataFile, sectionName, "TurnSpeed", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.turnspeed);
+            data[itemID][h].buildtime = loadIntValue(*objectDataFile, sectionName, "BuildTime", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.buildtime);
+            data[itemID][h].infspawnprop = loadIntValue(*objectDataFile, sectionName, "InfSpawnProp", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.infspawnprop);
+            data[itemID][h].builder = loadItemID(*objectDataFile, sectionName, "Builder", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.builder);
+            data[itemID][h].prerequisiteStructuresSet = loadPrerequisiteStructuresSet(*objectDataFile, sectionName, "Prerequisite", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.prerequisiteStructuresSet);
+            data[itemID][h].techLevel = loadIntValue(*objectDataFile, sectionName, "TechLevel", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.techLevel);
+            data[itemID][h].upgradeLevel = loadIntValue(*objectDataFile, sectionName, "UpgradeLevel", getHouseScenarioLetter(static_cast<HOUSETYPE>(h)), defaultData.upgradeLevel);
         }
     }
     
@@ -335,8 +335,10 @@ void ObjectData::save(OutputStream& stream) const
     stream.writeSint32(unitLimitHugeMap);
 }
 
-void ObjectData::load(InputStream& stream, int savedItemCount)
+void ObjectData::load(InputStream& stream, int savedItemCount, int savedHouseCount)
 {
+    savedHouseCount = std::max(1, std::min(savedHouseCount, static_cast<int>(NUM_HOUSES)));
+
     // For SAVEGAMEVERSION >= 9811, savedItemCount should be 0 (auto-read).
     if(savedItemCount == 0) {
         savedItemCount = static_cast<int>(stream.readUint32());
@@ -348,7 +350,7 @@ void ObjectData::load(InputStream& stream, int savedItemCount)
     int itemsToSkip = (savedItemCount > Num_ItemID) ? (savedItemCount - Num_ItemID) : 0;
 
     for(int i=0;i<itemsToLoad;i++) {
-        for(int h=0;h<NUM_HOUSES;h++) {
+        for(int h=0;h<savedHouseCount;h++) {
             data[i][h].enabled = stream.readBool();
             data[i][h].hitpoints = stream.readSint32();
             data[i][h].price = stream.readSint32();
@@ -372,7 +374,7 @@ void ObjectData::load(InputStream& stream, int savedItemCount)
     // Items beyond itemsToLoad but within Num_ItemID keep constructor defaults (zeroed/disabled).
     // Items beyond Num_ItemID in the stream must be consumed to keep alignment.
     for(int i=0;i<itemsToSkip;i++) {
-        for(int h=0;h<NUM_HOUSES;h++) {
+        for(int h=0;h<savedHouseCount;h++) {
             stream.readBool();
             stream.readSint32(); stream.readSint32(); stream.readSint32();
             stream.readSint32(); stream.readSint32(); stream.readSint32();
@@ -485,7 +487,7 @@ std::string ObjectData::getEffectiveHash() const {
     
     // Hash all unit/structure data for all houses
     for (int itemID = 0; itemID < Num_ItemID; itemID++) {
-        for (int houseID = 0; houseID < NUM_HOUSES; houseID++) {
+        for (int houseID = 0; houseID < getNumAvailableHouses(); houseID++) {
             const ObjectDataStruct& obj = data[itemID][houseID];
             
             // Add all gameplay-affecting fields

--- a/src/Tile.cpp
+++ b/src/Tile.cpp
@@ -118,7 +118,7 @@ bool shouldDrawTerrainBelowStructure(int itemID) noexcept {
 Tile::Tile() {
     type = Terrain_Sand;
 
-    for (auto i = 0; i < NUM_TEAMS; i++) {
+    for (auto i = 0; i < NUM_HOUSES; i++) {
         explored[i] = currentGame->getGameInitSettings().getGameOptions().startWithExploredMap;
         lastAccess[i] = 0;
     }
@@ -149,12 +149,15 @@ void Tile::load(InputStream& stream) {
     type = stream.readUint32();
 
     stream.readBools(&explored[0], &explored[1], &explored[2], &explored[3], &explored[4], &explored[5], &explored[6], &explored[7]);
+    explored[HOUSE_CUSTOM] = (currentGame && currentGame->getLoadedSavegameVersion() >= 9821)
+        ? stream.readBool()
+        : false;
 
-    // Tile visibility is indexed by house (0..7), not by the 1-based team ID.
-    // NUM_TEAMS is 9 so other arrays can address team IDs 0..8; using it here
-    // left bLastAccess[8] uninitialized because readBools stores only 8 bits.
     bool bLastAccess[NUM_HOUSES]{};
     stream.readBools(&bLastAccess[0], &bLastAccess[1], &bLastAccess[2], &bLastAccess[3], &bLastAccess[4], &bLastAccess[5], &bLastAccess[6], &bLastAccess[7]);
+    if(currentGame && currentGame->getLoadedSavegameVersion() >= 9821) {
+        bLastAccess[HOUSE_CUSTOM] = stream.readBool();
+    }
 
     for (int i = 0; i < NUM_HOUSES; i++) {
         if (bLastAccess[i] == true) {
@@ -243,8 +246,10 @@ void Tile::save(OutputStream& stream) const {
     stream.writeUint32(type);
 
     stream.writeBools(explored[0], explored[1], explored[2], explored[3], explored[4], explored[5], explored[6], explored[7]);
+    stream.writeBool(explored[HOUSE_CUSTOM]);
 
     stream.writeBools((lastAccess[0] != 0), (lastAccess[1] != 0), (lastAccess[2] != 0), (lastAccess[3] != 0), (lastAccess[4] != 0), (lastAccess[5] != 0), (lastAccess[6] != 0), (lastAccess[7] != 0));
+    stream.writeBool(lastAccess[HOUSE_CUSTOM] != 0);
     for (int i = 0; i < NUM_HOUSES; ++i) {
         if (lastAccess[i] != 0) {
             stream.writeUint32(lastAccess[i]);

--- a/src/dunecity/CitySimulation.cpp
+++ b/src/dunecity/CitySimulation.cpp
@@ -70,7 +70,10 @@ void CitySimulation::load(InputStream& stream) {
         lastBudgetTick_          = (lastProcessedDay_ * kCyclesPerCityDay) / kCyclesPerBudgetTick;
         economicVictoryThreshold_= stream.readSint32();
 
-        for (int h = 0; h < kMaxCityHouses; ++h) {
+        const int savedCityHouseCount = loadedVersion >= 9821
+            ? kMaxCityHouses
+            : NUM_LEGACY_HOUSES;
+        for (int h = 0; h < savedCityHouseCount; ++h) {
             houseState_[h].load(stream);
         }
     } else {

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <globals.h>
+#include <mod/ModManager.h>
 
 #include <SoundPlayer.h>
 #include <FileClasses/music/MusicPlayer.h>
@@ -72,7 +73,8 @@ std::array<int, NUM_HOUSES> houseToVisualHouse = {
     HOUSE_SARDAUKAR,
     HOUSE_MERCENARY,
     HOUSE_NEUTRAL,
-    HOUSE_REBELS
+    HOUSE_REBELS,
+    HOUSE_CUSTOM
 };
 
 void loadCustomPalette() {
@@ -105,6 +107,52 @@ void applyCustomPaletteRuntimeHouseRamps() {
         color.b = rebelsGreyRamp[k];
         color.a = 255;
     }
+}
+
+bool isHouseAvailable(HOUSETYPE house) {
+    if(house >= HOUSE_HARKONNEN && house < NUM_LEGACY_HOUSES) return true;
+    return house == HOUSE_CUSTOM
+        && ModManager::instance().isInitialized()
+        && ModManager::instance().isCustomHouseRegistered();
+}
+
+int getNumAvailableHouses() {
+    return NUM_LEGACY_HOUSES + (isHouseAvailable(HOUSE_CUSTOM) ? 1 : 0);
+}
+
+char getHouseScenarioLetter(HOUSETYPE house) {
+    if(house == HOUSE_CUSTOM) {
+        const CustomHouseInfo& info = ModManager::instance().getActiveCustomHouseInfo();
+        return isHouseAvailable(house) ? info.scenarioLetter : '?';
+    }
+    return (house >= HOUSE_HARKONNEN && house < NUM_LEGACY_HOUSES) ? houseChar[house] : '?';
+}
+
+std::string getHouseRegionPrefix(HOUSETYPE house) {
+    if(house == HOUSE_CUSTOM) {
+        const CustomHouseInfo& info = ModManager::instance().getActiveCustomHouseInfo();
+        return isHouseAvailable(house) ? info.regionPrefix : std::string();
+    }
+    static const char* const prefixes[NUM_LEGACY_HOUSES] = {
+        "HAR", "ATR", "ORD", "FRE", "SAR", "MER", "NEU", "REB"
+    };
+    return (house >= HOUSE_HARKONNEN && house < NUM_LEGACY_HOUSES) ? prefixes[house] : std::string();
+}
+
+int getHousePaletteIndex(HOUSETYPE house) {
+    if(house == HOUSE_CUSTOM) {
+        const CustomHouseInfo& info = ModManager::instance().getActiveCustomHouseInfo();
+        return isHouseAvailable(house) ? info.paletteIndex : PALCOLOR_HARKONNEN;
+    }
+    return (house >= HOUSE_HARKONNEN && house < NUM_LEGACY_HOUSES)
+        ? houseToPaletteIndex[house]
+        : PALCOLOR_HARKONNEN;
+}
+
+HOUSETYPE getHouseFallbackHouse(HOUSETYPE house) {
+    if(house != HOUSE_CUSTOM) return house;
+    const CustomHouseInfo& info = ModManager::instance().getActiveCustomHouseInfo();
+    return isHouseAvailable(house) ? static_cast<HOUSETYPE>(info.fallbackHouse) : HOUSE_HARKONNEN;
 }
 
 void resetHouseVisualHouseMapping() {

--- a/src/mod/ModManager.cpp
+++ b/src/mod/ModManager.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <mod/ModManager.h>
+#include <mod/CustomHouseConfig.h>
 #include <FileClasses/GFXManager.h>
 #include <FileClasses/TextManager.h>
 #include <misc/fnkdat.h>
@@ -1175,6 +1176,7 @@ ModInfo ModManager::readModIni(const std::string& modPath) const {
     if(customFile.is_open()) {
         std::string section;
         bool requestedEnabled = false;
+        bool numericFieldsValid = true;
         while(std::getline(customFile, line)) {
             trim(line);
             if(line.empty() || line[0] == '#' || line[0] == ';') continue;
@@ -1205,9 +1207,13 @@ ModInfo ModManager::readModIni(const std::string& modPath) const {
                     if(value >= 'a' && value <= 'z') value = static_cast<char>(value - 'a' + 'A');
                 }
             } else if(customKey == "Palette Index") {
-                info.customHouse.paletteIndex = std::stoi(customValue);
+                if(!CustomHouseConfig::parseInteger(customValue, info.customHouse.paletteIndex)) {
+                    numericFieldsValid = false;
+                }
             } else if(customKey == "Fallback House") {
-                info.customHouse.fallbackHouse = std::stoi(customValue);
+                if(!CustomHouseConfig::parseInteger(customValue, info.customHouse.fallbackHouse)) {
+                    numericFieldsValid = false;
+                }
             }
         }
 
@@ -1218,7 +1224,7 @@ ModInfo ModManager::readModIni(const std::string& modPath) const {
         const bool fallbackValid = info.customHouse.fallbackHouse >= 0
             && info.customHouse.fallbackHouse < NUM_LEGACY_HOUSES;
         info.customHouse.enabled = requestedEnabled && !info.customHouse.displayName.empty()
-            && letterValid && prefixValid && paletteValid && fallbackValid;
+            && numericFieldsValid && letterValid && prefixValid && paletteValid && fallbackValid;
         if(requestedEnabled && !info.customHouse.enabled) {
             SDL_Log("ModManager: Ignoring invalid generic custom-house registration in %s", modPath.c_str());
         }

--- a/src/mod/ModManager.cpp
+++ b/src/mod/ModManager.cpp
@@ -49,6 +49,7 @@ static const char* DUNE2R_MOD_NAME = "Dune2R";
 // Install config file names (with .default suffix)
 static const char* OBJECT_DATA_DEFAULT = "ObjectData.ini.default";
 static const char* QUANTBOT_CONFIG_DEFAULT = "QuantBot Config.ini.default";
+static const char* CUSTOM_HOUSE_CONFIG = "CustomHouse.ini";
 
 ModManager& ModManager::instance() {
     static ModManager instance;
@@ -116,12 +117,21 @@ void ModManager::initialize() {
         saveActiveMod();
     }
     
+    activeCustomHouse = readModIni(getModPath(activeMod)).customHouse;
     initialized = true;
     SDL_Log("ModManager: Initialized with active mod '%s'", activeMod.c_str());
 }
 
 std::string ModManager::getActiveModName() const {
     return activeMod;
+}
+
+const CustomHouseInfo& ModManager::getActiveCustomHouseInfo() const {
+    return activeCustomHouse;
+}
+
+bool ModManager::isCustomHouseRegistered() const {
+    return initialized && activeCustomHouse.enabled;
 }
 
 bool ModManager::isCityModeActive() const {
@@ -141,6 +151,7 @@ bool ModManager::setActiveMod(const std::string& name) {
     }
     
     activeMod = name;
+    activeCustomHouse = readModIni(getModPath(activeMod)).customHouse;
     checksumsDirty = true;
     saveActiveMod();
     if(pTextManager != nullptr) {
@@ -452,8 +463,14 @@ void ModManager::updateChecksums() {
         cachedChecksums.gameOptions = "0000000000000000";
     }
     
-    // Combined hash
-    std::string combined = cachedChecksums.objectData + cachedChecksums.quantBotConfig + cachedChecksums.gameOptions;
+    const std::string customHousePath = getModPath(activeMod) + "/" + CUSTOM_HOUSE_CONFIG;
+    cachedChecksums.customHouse = existsFile(customHousePath)
+        ? hashFileCanonical(customHousePath)
+        : std::string();
+
+    // Appending an empty optional hash preserves the exact legacy checksum.
+    std::string combined = cachedChecksums.objectData + cachedChecksums.quantBotConfig
+        + cachedChecksums.gameOptions + cachedChecksums.customHouse;
     uint64_t hash = 14695981039346656037ULL;
     const uint64_t prime = 1099511628211ULL;
     for (char c : combined) {
@@ -1123,6 +1140,11 @@ ModInfo ModManager::readModIni(const std::string& modPath) const {
     }
     
     // Simple INI parsing (key = value format)
+    auto trim = [](std::string& s) {
+        while (!s.empty() && (s.front() == ' ' || s.front() == '\t')) s.erase(0, 1);
+        while (!s.empty() && (s.back() == ' ' || s.back() == '\t' || s.back() == '\n' || s.back() == '\r')) s.pop_back();
+    };
+
     std::string line;
     while (std::getline(file, line)) {
         // Skip empty lines and comments
@@ -1133,12 +1155,6 @@ ModInfo ModManager::readModIni(const std::string& modPath) const {
         
         std::string key = line.substr(0, equalsPos);
         std::string value = line.substr(equalsPos + 1);
-        
-        // Trim whitespace
-        auto trim = [](std::string& s) {
-            while (!s.empty() && (s.front() == ' ' || s.front() == '\t')) s.erase(0, 1);
-            while (!s.empty() && (s.back() == ' ' || s.back() == '\t' || s.back() == '\n' || s.back() == '\r')) s.pop_back();
-        };
         
         trim(key);
         trim(value);
@@ -1154,6 +1170,59 @@ ModInfo ModManager::readModIni(const std::string& modPath) const {
     }
     
     file.close();
+
+    std::ifstream customFile(modPath + "/" + CUSTOM_HOUSE_CONFIG);
+    if(customFile.is_open()) {
+        std::string section;
+        bool requestedEnabled = false;
+        while(std::getline(customFile, line)) {
+            trim(line);
+            if(line.empty() || line[0] == '#' || line[0] == ';') continue;
+            if(line.front() == '[' && line.back() == ']') {
+                section = line.substr(1, line.size() - 2);
+                trim(section);
+                continue;
+            }
+            if(section != "House") continue;
+
+            const size_t customEqualsPos = line.find('=');
+            if(customEqualsPos == std::string::npos) continue;
+            std::string customKey = line.substr(0, customEqualsPos);
+            std::string customValue = line.substr(customEqualsPos + 1);
+            trim(customKey);
+            trim(customValue);
+
+            if(customKey == "Enabled") {
+                requestedEnabled = (customValue == "true" || customValue == "1" || customValue == "yes");
+            } else if(customKey == "Display Name") {
+                info.customHouse.displayName = customValue;
+            } else if(customKey == "Scenario Letter" && customValue.size() == 1) {
+                char value = customValue[0];
+                info.customHouse.scenarioLetter = (value >= 'a' && value <= 'z') ? static_cast<char>(value - 'a' + 'A') : value;
+            } else if(customKey == "Region Prefix") {
+                info.customHouse.regionPrefix = customValue;
+                for(char& value : info.customHouse.regionPrefix) {
+                    if(value >= 'a' && value <= 'z') value = static_cast<char>(value - 'a' + 'A');
+                }
+            } else if(customKey == "Palette Index") {
+                info.customHouse.paletteIndex = std::stoi(customValue);
+            } else if(customKey == "Fallback House") {
+                info.customHouse.fallbackHouse = std::stoi(customValue);
+            }
+        }
+
+        const bool letterValid = info.customHouse.scenarioLetter >= 'A' && info.customHouse.scenarioLetter <= 'Z';
+        const bool prefixValid = info.customHouse.regionPrefix.size() == 3
+            && info.customHouse.regionPrefix.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == std::string::npos;
+        const bool paletteValid = info.customHouse.paletteIndex >= 0 && info.customHouse.paletteIndex <= 248;
+        const bool fallbackValid = info.customHouse.fallbackHouse >= 0
+            && info.customHouse.fallbackHouse < NUM_LEGACY_HOUSES;
+        info.customHouse.enabled = requestedEnabled && !info.customHouse.displayName.empty()
+            && letterValid && prefixValid && paletteValid && fallbackValid;
+        if(requestedEnabled && !info.customHouse.enabled) {
+            SDL_Log("ModManager: Ignoring invalid generic custom-house registration in %s", modPath.c_str());
+        }
+    }
     return info;
 }
 

--- a/src/players/AIPlayer.cpp
+++ b/src/players/AIPlayer.cpp
@@ -356,7 +356,7 @@ void AIPlayer::build() {
             if(pStructure->getItemID() == Structure_Palace) {
                 const Palace* pPalace = static_cast<const Palace*>(pStructure);
                 if(pPalace->isSpecialWeaponReady()) {
-                    const HOUSETYPE palaceHouse = static_cast<HOUSETYPE>(pPalace->getOriginalHouseID());
+                    const HOUSETYPE palaceHouse = getHouseFallbackHouse(static_cast<HOUSETYPE>(pPalace->getOriginalHouseID()));
                     if(palaceHouse == HOUSE_HARKONNEN || palaceHouse == HOUSE_SARDAUKAR) {
                         const House* pBestHouse = nullptr;
                         for(int i = 0; i < NUM_HOUSES; i++) {
@@ -759,9 +759,9 @@ void AIPlayer::checkAllUnits() {
 }
 
 bool AIPlayer::isAllowedToArm() const {
-    int teamScore[NUM_TEAMS];
+    int teamScore[NUM_TEAM_SLOTS];
 
-    for(int i = 0; i < NUM_TEAMS; i++) {
+    for(int i = 0; i < NUM_TEAM_SLOTS; i++) {
         teamScore[i] = 0;
     }
 

--- a/src/players/CampaignAIPlayer.cpp
+++ b/src/players/CampaignAIPlayer.cpp
@@ -333,8 +333,8 @@ void CampaignAIPlayer::updateStructures() {
         if(pStructure->getItemID() == Structure_Palace) {
             const Palace* pPalace = static_cast<const Palace*>(pStructure);
             if(pPalace->isSpecialWeaponReady()) {
-                if(getHouse()->getHouseID() != HOUSE_HARKONNEN && 
-                   getHouse()->getHouseID() != HOUSE_SARDAUKAR) {
+                const HOUSETYPE palaceHouse = getHouseFallbackHouse(static_cast<HOUSETYPE>(getHouse()->getHouseID()));
+                if(palaceHouse != HOUSE_HARKONNEN && palaceHouse != HOUSE_SARDAUKAR) {
                     doSpecialWeapon(pPalace);
                 } else {
                     // Death Hand - target house with most structures

--- a/src/sand.cpp
+++ b/src/sand.cpp
@@ -18,6 +18,7 @@
 #include <sand.h>
 
 #include <globals.h>
+#include <mod/ModManager.h>
 
 #include <FileClasses/GFXManager.h>
 #include <FileClasses/TextManager.h>
@@ -492,6 +493,8 @@ HOUSETYPE getHouseByName(const std::string& name) {
     else if(lowerName == "mercenary")    return HOUSE_MERCENARY;
     else if(lowerName == "neutral")      return HOUSE_NEUTRAL;
     else if((lowerName == "rebel") || (lowerName == "rebels")) return HOUSE_REBELS;
+    else if(isHouseAvailable(HOUSE_CUSTOM)
+            && lowerName == strToLower(ModManager::instance().getActiveCustomHouseInfo().displayName)) return HOUSE_CUSTOM;
     else                                return HOUSE_INVALID;
 }
 
@@ -501,20 +504,18 @@ HOUSETYPE getHouseByName(const std::string& name) {
     \return the name of the house (e.g. "Atreides").
 */
 std::string getHouseNameByNumber(HOUSETYPE house) {
-    if(house >= 0 && house < NUM_HOUSES) {
-        static const char* const houseName[NUM_HOUSES] = {  "Harkonnen",
-                                                            "Atreides",
-                                                            "Ordos",
-                                                            "Fremen",
-                                                            "Sardaukar",
-                                                            "Mercenary",
-                                                            "Neutral",
-                                                            "Rebels"
-                                                   };
-        return houseName[house];
-    } else {
-        THROW(std::invalid_argument, "Invalid house number %d!", house);
+    if(house == HOUSE_CUSTOM) {
+        if(isHouseAvailable(house)) return ModManager::instance().getActiveCustomHouseInfo().displayName;
+        return "Custom";
     }
+    if(house >= 0 && house < NUM_LEGACY_HOUSES) {
+        static const char* const houseName[NUM_LEGACY_HOUSES] = {
+            "Harkonnen", "Atreides", "Ordos", "Fremen", "Sardaukar",
+            "Mercenary", "Neutral", "Rebels"
+        };
+        return houseName[house];
+    }
+    THROW(std::invalid_argument, "Invalid house number %d!", house);
 }
 
 ATTACKMODE getAttackModeByName(const std::string& name) {

--- a/src/structures/Palace.cpp
+++ b/src/structures/Palace.cpp
@@ -103,7 +103,7 @@ void Palace::doSpecialWeapon() {
         return;
     }
 
-    switch (originalHouseID) {
+    switch (getHouseFallbackHouse(static_cast<HOUSETYPE>(originalHouseID))) {
         case HOUSE_HARKONNEN:
         case HOUSE_SARDAUKAR: {
             // wrong house (see DoLaunchDeathhand)
@@ -143,7 +143,8 @@ void Palace::doLaunchDeathhand(int x, int y) {
         return;
     }
 
-    if((originalHouseID != HOUSE_HARKONNEN) && (originalHouseID != HOUSE_SARDAUKAR)) {
+    const HOUSETYPE palaceHouse = getHouseFallbackHouse(static_cast<HOUSETYPE>(originalHouseID));
+    if((palaceHouse != HOUSE_HARKONNEN) && (palaceHouse != HOUSE_SARDAUKAR)) {
         // wrong house (see DoSpecialWeapon)
         return;
     }
@@ -187,7 +188,7 @@ void Palace::updateStructureSpecificStuff() {
                 currentGame->addToNewsTicker(_("Palace is ready"));
             } else if(getOwner()->isAI()) {
 
-                if((originalHouseID == HOUSE_HARKONNEN) || (originalHouseID == HOUSE_SARDAUKAR)) {
+                if((getHouseFallbackHouse(static_cast<HOUSETYPE>(originalHouseID)) == HOUSE_HARKONNEN) || (getHouseFallbackHouse(static_cast<HOUSETYPE>(originalHouseID)) == HOUSE_SARDAUKAR)) {
                     // Harkonnen and Sardaukar
 
                     //old tergetting logic used by default AI

--- a/src/units/Saboteur.cpp
+++ b/src/units/Saboteur.cpp
@@ -66,8 +66,8 @@ void Saboteur::checkPos()
     InfantryBase::checkPos();
 
     if(active) {
-        bool canBeSeen[NUM_TEAMS];
-        for(int i = 0; i < NUM_TEAMS; i++) {
+        bool canBeSeen[NUM_TEAM_SLOTS];
+        for(int i = 0; i < NUM_TEAM_SLOTS; i++) {
             canBeSeen[i] = false;
         }
 
@@ -79,7 +79,7 @@ void Saboteur::checkPos()
             }
         }
 
-        for(int i = 0; i < NUM_TEAMS; i++) {
+        for(int i = 0; i < NUM_TEAM_SLOTS; i++) {
             setVisible(i, canBeSeen[i]);
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,13 +29,7 @@ target_sources(dunelegacy_tests
         ValueModelTestCase/ValueModelTestCase.cpp
         PoliceStationTestCase/PoliceStationTestCase.cpp
         SaveCompatTestCase/SaveCompatTestCase.cpp
-        # NeutralHouseTestCase disabled in v1.0.513: the test references
-        # Anim_NeutralEyes/Mouth/Shoulder/Ring and HouseNeutral, none of
-        # which exist in the current build. The Neutral house is a planned
-        # future addition; the test was checked in ahead of the
-        # implementation. Re-enable when the Anim_Neutral* and HouseNeutral
-        # symbols land.
-        # NeutralHouseTestCase/NeutralHouseTestCase.cpp
+        NeutralHouseTestCase/NeutralHouseTestCase.cpp
         # DuneCity core sources (needed for CitySimulation tests)
         ${CMAKE_SOURCE_DIR}/src/dunecity/CitySimulation.cpp
         CityEffectsRuntime_test_stub.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(dunelegacy_tests
     PRIVATE
         PathBudgetTestCase/PathBudgetTestCase.cpp
         NetworkManagerTestCase/NetworkManagerTestCase.cpp
+        GenericNinthHouseRegressionTestCase/GenericNinthHouseRegressionTestCase.cpp
         ZoneStructureTestCase/ZoneStructureTestCase.cpp
         RoadPlacementTestCase/RoadPlacementTestCase.cpp
         CityBudgetIntegrationTestCase/CityBudgetIntegrationTestCase.cpp

--- a/tests/GenericNinthHouseRegressionTestCase/GenericNinthHouseRegressionTestCase.cpp
+++ b/tests/GenericNinthHouseRegressionTestCase/GenericNinthHouseRegressionTestCase.cpp
@@ -1,0 +1,52 @@
+#include <catch2/catch_all.hpp>
+
+#include <INIMap/MapPlayerSectionUtils.h>
+#include <mod/CustomHouseConfig.h>
+
+#include <array>
+#include <string>
+
+TEST_CASE("CustomHouse config: valid numeric fields parse without throwing",
+          "[custom-house][config]") {
+    int value = -1;
+    REQUIRE(CustomHouseConfig::parseInteger("144", value));
+    REQUIRE(value == 144);
+
+    REQUIRE(CustomHouseConfig::parseInteger("0", value));
+    REQUIRE(value == 0);
+}
+
+TEST_CASE("CustomHouse config: malformed numeric fields are rejected without mutation",
+          "[custom-house][config][regression]") {
+    const std::array<std::string, 5> malformedValues = {
+        "",
+        "not-a-number",
+        "144trailing",
+        "144 ",
+        "999999999999999999999999999999"
+    };
+
+    for(const std::string& malformedValue : malformedValues) {
+        CAPTURE(malformedValue);
+        int destination = 73;
+        REQUIRE_FALSE(CustomHouseConfig::parseInteger(malformedValue, destination));
+        REQUIRE(destination == 73);
+    }
+}
+
+TEST_CASE("PlayerN-only map scans the fixed available-house capacity",
+          "[map][players][regression]") {
+    constexpr int availableHouseCapacity = 8;
+    int sectionsScanned = 0;
+
+    const int numberedPlayerCount = MapPlayerSectionUtils::countNumberedPlayerSections(
+        availableHouseCapacity,
+        [&sectionsScanned](int playerNumber) {
+            ++sectionsScanned;
+            return playerNumber == 1 || playerNumber == 8;
+        });
+
+    REQUIRE(sectionsScanned == availableHouseCapacity);
+    REQUIRE(numberedPlayerCount == 2);
+    REQUIRE(0 + numberedPlayerCount == 2);
+}

--- a/tests/NetworkManagerTestCase/NetworkManagerTestCase.cpp
+++ b/tests/NetworkManagerTestCase/NetworkManagerTestCase.cpp
@@ -27,6 +27,35 @@ TEST_CASE("NetworkManager: nine-house state requires protocol 4", "[network][pro
     REQUIRE(NETWORKDISCONNECT_PROTOCOL_MISMATCH == 5);
 }
 
+TEST_CASE("NetworkManager: current protocol handshake does not disconnect",
+          "[network][protocol][handshake]") {
+    bool disconnectCalled = false;
+    const bool rejected = rejectIncompatibleNetworkProtocol(
+        NETWORK_PROTOCOL_VERSION,
+        [&disconnectCalled](int) {
+            disconnectCalled = true;
+        });
+
+    REQUIRE_FALSE(rejected);
+    REQUIRE_FALSE(disconnectCalled);
+}
+
+TEST_CASE("NetworkManager: mismatched protocol handshake dispatches rejection cause",
+          "[network][protocol][handshake][regression]") {
+    bool disconnectCalled = false;
+    int disconnectCause = -1;
+    const bool rejected = rejectIncompatibleNetworkProtocol(
+        NETWORK_PROTOCOL_VERSION - 1,
+        [&disconnectCalled, &disconnectCause](int cause) {
+            disconnectCalled = true;
+            disconnectCause = cause;
+        });
+
+    REQUIRE(rejected);
+    REQUIRE(disconnectCalled);
+    REQUIRE(disconnectCause == NETWORKDISCONNECT_PROTOCOL_MISMATCH);
+}
+
 // ENet initialization fixture
 struct ENetFixture {
     ENetFixture() {

--- a/tests/NetworkManagerTestCase/NetworkManagerTestCase.cpp
+++ b/tests/NetworkManagerTestCase/NetworkManagerTestCase.cpp
@@ -8,6 +8,7 @@
 #include <catch2/catch_all.hpp>
 
 #include <Network/ENetHelper.h>
+#include <Network/NetworkManager.h>
 #include <Network/ENetPacketOStream.h>
 #include <Network/ENetPacketIStream.h>
 
@@ -18,7 +19,13 @@
 #define TEST_NETWORKPACKET_SENDGAMEINFO         1
 #define TEST_NETWORKPACKET_CLIENTSTATS          13
 #define TEST_NETWORKPACKET_KEEPALIVE            19
-#define TEST_NETWORK_PROTOCOL_VERSION           3
+#define TEST_NETWORK_PROTOCOL_VERSION           4
+
+TEST_CASE("NetworkManager: nine-house state requires protocol 4", "[network][protocol]") {
+    REQUIRE(NETWORK_PROTOCOL_VERSION == 4);
+    REQUIRE(TEST_NETWORK_PROTOCOL_VERSION != 3);
+    REQUIRE(NETWORKDISCONNECT_PROTOCOL_MISMATCH == 5);
+}
 
 // ENet initialization fixture
 struct ENetFixture {

--- a/tests/NeutralHouseTestCase/NeutralHouseTestCase.cpp
+++ b/tests/NeutralHouseTestCase/NeutralHouseTestCase.cpp
@@ -1,8 +1,8 @@
 /*
  *  NeutralHouseTestCase.cpp - Tests for the Neutral house (v1.0.111-120)
  *
- *  Validates: house enum, palette color, radar color, mentat animation
- *  registration, voice enum, skirmish availability (source scan), and
+ *  Validates: house enum, legacy ID stability, palette fallback,
+ *  voice resources, skirmish availability (source scan), and
  *  ObjectData.ini prerequisites for Neutral-specific entries.
  *
  *  Source-scan tests skip gracefully when DUNE_CITY_SOURCE_DIR is not set.
@@ -41,7 +41,7 @@ TEST_CASE("NeutralHouse: HOUSE_NEUTRAL exists in the house enum",
           "[neutral][enum]") {
     REQUIRE(HOUSE_NEUTRAL == 6);
     // NUM_HOUSES must include Neutral + Rebels (0..7 → 8 total as of v1.0.228)
-    REQUIRE(NUM_HOUSES == 8);
+    REQUIRE(NUM_HOUSES == 9);
 }
 
 TEST_CASE("NeutralHouse: HOUSE_NEUTRAL is after HOUSE_MERCENARY",
@@ -52,7 +52,7 @@ TEST_CASE("NeutralHouse: HOUSE_NEUTRAL is after HOUSE_MERCENARY",
 TEST_CASE("NeutralHouse: savegame version includes HOUSE_NEUTRAL",
           "[neutral][savegame]") {
     // SAVEGAMEVERSION 9818 persists all kMaxCityHouses houseState[] slots (9817 added House::cityCredits, 9816 added Unit_EliteSiegeTank=55, 9813 added HOUSE_NEUTRAL).
-    REQUIRE(SAVEGAMEVERSION == 9820);
+    REQUIRE(SAVEGAMEVERSION == 9821);
 }
 
 // =============================================================================
@@ -73,35 +73,28 @@ TEST_CASE("NeutralHouse: houseToPaletteIndex maps HOUSE_NEUTRAL to PALCOLOR_NEUT
 // Mentat animation enum registration
 // =============================================================================
 
-TEST_CASE("NeutralHouse: Neutral mentat animation enum values are registered",
-          "[neutral][mentat]") {
-    // These enums must exist so MentatMenu can construct the Neutral mentat.
-    // Verify they compile and are valid (> 0) in the animation enum.
-    REQUIRE(Anim_NeutralEyes   >= 0);
-    REQUIRE(Anim_NeutralMouth  >= 0);
-    REQUIRE(Anim_NeutralShoulder >= 0);
-    REQUIRE(Anim_NeutralRing   >= 0);
+TEST_CASE("NeutralHouse: legacy house IDs remain stable with generic ninth-house capacity",
+          "[neutral][enum][compat]") {
+    REQUIRE(HOUSE_HARKONNEN == 0);
+    REQUIRE(HOUSE_ATREIDES == 1);
+    REQUIRE(HOUSE_ORDOS == 2);
+    REQUIRE(HOUSE_FREMEN == 3);
+    REQUIRE(HOUSE_SARDAUKAR == 4);
+    REQUIRE(HOUSE_MERCENARY == 5);
+    REQUIRE(HOUSE_NEUTRAL == 6);
+    REQUIRE(HOUSE_REBELS == 7);
+    REQUIRE(NUM_LEGACY_HOUSES == 8);
+    REQUIRE(HOUSE_CUSTOM == NUM_LEGACY_HOUSES);
+    REQUIRE(NUM_HOUSES == NUM_LEGACY_HOUSES + 1);
 }
-
-TEST_CASE("NeutralHouse: Neutral mentat animations are distinct from each other",
-          "[neutral][mentat]") {
-    REQUIRE(Anim_NeutralEyes   != Anim_NeutralMouth);
-    REQUIRE(Anim_NeutralEyes   != Anim_NeutralShoulder);
-    REQUIRE(Anim_NeutralMouth  != Anim_NeutralRing);
-}
-
 // =============================================================================
 // Voice file mapping (source scan)
 // =============================================================================
 
-TEST_CASE("NeutralHouse: HouseNeutral voice enum is registered in SFXManager",
-          "[neutral][voice]") {
-    // Voice enum must include HouseNeutral before NUM_VOICE.
-    REQUIRE(HouseNeutral < NUM_VOICE);
-    // It follows HouseOrdos in the enum.
-    REQUIRE(HouseNeutral == HouseOrdos + 1);
+TEST_CASE("NeutralHouse: generic custom slot has a safe legacy palette fallback",
+          "[neutral][color][compat]") {
+    REQUIRE(houseToPaletteIndex[HOUSE_CUSTOM] == PALCOLOR_HARKONNEN);
 }
-
 TEST_CASE("NeutralHouse: ANEU.VOC is the primary voice file for Neutral house announcement",
           "[neutral][voice][source-scan]") {
     std::string src = readSourceFile("src/FileClasses/SFXManager.cpp");
@@ -112,18 +105,6 @@ TEST_CASE("NeutralHouse: ANEU.VOC is the primary voice file for Neutral house an
     auto pos = src.find("ANEU.VOC");
     INFO("SFXManager.cpp must reference ANEU.VOC for Neutral house name");
     REQUIRE(pos != std::string::npos);
-}
-
-TEST_CASE("NeutralHouse: HNEU.VOC and ONEU.VOC are referenced for Harkonnen/Ordos branches",
-          "[neutral][voice][source-scan]") {
-    std::string src = readSourceFile("src/FileClasses/SFXManager.cpp");
-    REQUIRE_FALSE(src.empty());
-
-    INFO("SFXManager.cpp must reference HNEU.VOC for Harkonnen/Sardaukar branch");
-    REQUIRE(src.find("HNEU.VOC") != std::string::npos);
-
-    INFO("SFXManager.cpp must reference ONEU.VOC for Ordos/Mercenary branch");
-    REQUIRE(src.find("ONEU.VOC") != std::string::npos);
 }
 
 // =============================================================================

--- a/tests/SaveCompatTestCase/SaveCompatTestCase.cpp
+++ b/tests/SaveCompatTestCase/SaveCompatTestCase.cpp
@@ -14,6 +14,7 @@
 #include <DataTypes.h>
 #include <Definitions.h>
 #include <misc/SaveCompat.h>
+#include <mod/ModInfo.h>
 
 // ---------- constant checks ----------
 
@@ -35,14 +36,31 @@ TEST_CASE("Save compat: current Num_ItemID >= legacy",
 
 TEST_CASE("Save compat: SAVEGAMEVERSION is 9811 or higher",
           "[save-compat][regression]") {
-    REQUIRE(SAVEGAMEVERSION == 9820);
+    REQUIRE(SAVEGAMEVERSION == 9821);
     REQUIRE(SAVEGAMEVERSION >= 9818);
 }
 
-TEST_CASE("Save compat: tile house visibility fits its packed byte",
+TEST_CASE("Save compat: ninth house extends rather than reorders legacy IDs",
           "[save-compat][regression]") {
-    REQUIRE(NUM_HOUSES == 8);
-    REQUIRE(NUM_TEAMS >= NUM_HOUSES);
+    REQUIRE(NUM_LEGACY_HOUSES == 8);
+    REQUIRE(HOUSE_REBELS == 7);
+    REQUIRE(HOUSE_CUSTOM == 8);
+    REQUIRE(NUM_HOUSES == 9);
+    REQUIRE(NUM_TEAM_SLOTS == 10);
+}
+
+TEST_CASE("Save compat: old visual color slots retain their meaning",
+          "[save-compat][regression]") {
+    REQUIRE(migrateLegacyHouseColorSlot(7) == 7);
+    REQUIRE(migrateLegacyHouseColorSlot(8) == 9);
+    REQUIRE(migrateLegacyHouseColorSlot(13) == 14);
+}
+
+TEST_CASE("Save compat: generic custom house is disabled by default",
+          "[save-compat][regression]") {
+    const CustomHouseInfo info;
+    REQUIRE_FALSE(info.enabled);
+    REQUIRE(info.scenarioLetter == '?');
 }
 
 TEST_CASE("Save compat: new items are at indices >= LEGACY_NUM_ITEM_ID_9810",


### PR DESCRIPTION
## Summary

This PR adds a fixed, generic ninth-house engine capacity while preserving the existing house IDs and behavior.

- Keeps house IDs 0 through 7 unchanged.
- Reserves ID 8 as `HOUSE_CUSTOM`.
- Keeps the custom slot unavailable and invisible unless the active mod explicitly registers it through `CustomHouse.ini`.
- Adds generic registration fields for display name, scenario letter, region prefix, palette index, and fallback house.
- Expands house-indexed engine state, player/team handling, AI paths, menus, map parsing, palettes, and campaign filename resolution to safely account for the ninth slot.
- Uses generic fallback behavior for palace logic, voices, graphics, and palettes.
- Includes the optional custom-house configuration hash in synchronized mod checksums.

## Scope and isolation

This is the generic engine PR only.

- No Tornie or Tharpique names, assets, paths, defaults, or hard-coded behavior are included.
- Vanilla, DuneCity, and Dune2R retain eight selectable houses and their existing ordering unless a mod explicitly registers the generic custom slot.
- No application or Android release version was changed.
- Tornie content and mod-specific Mentat content remain deferred to their separate PRs.

## Save compatibility

- Increments `SAVEGAMEVERSION` from 9820 to 9821.
- Existing supported saves continue to load with eight legacy houses.
- Missing ninth-house state initializes to safe defaults.
- New saves persist nine-house ObjectData, game-house state, and city simulation state.
- Tile visibility preserves the existing eight-bit field and stores the ninth visibility flag separately for version 9821 saves.
- Object/team visibility uses versioned extra storage rather than reinterpreting legacy bits.

## Multiplayer

The deterministic synchronized state changes, so this PR increments `NETWORK_PROTOCOL_VERSION` from 3 to 4.

- Incompatible clients are rejected with an explicit protocol-mismatch disconnect reason.
- Current clients synchronize the active mod and combined configuration checksum, including optional custom-house registration.
- Existing house ordering remains unchanged for eight-house current-client sessions.

## Custom registration format

The active mod may opt in with `CustomHouse.ini`:

```ini
[House]
Enabled = true
Display Name = Custom
Scenario Letter = C
Region Prefix = CUS
Palette Index = 144
Fallback House = 0
```

Invalid or incomplete registration remains disabled and falls back safely.

## Validation

Base and latest upstream at submission time:

- `VR48/dunecity:main` at `c6ada7aa797dda1b99cbf6d20a96dc403e68efa9`

Local Windows validation:

- Full Debug build completed successfully with MSYS2 GCC 15.2.
- `dunecity.exe` linked successfully and build data/config/mod copy targets completed.
- Full CTest suite passed with zero failures.
- Relevant coverage includes `SaveCompatTestCase`, `NeutralHouseTestCase`, and `NetworkManagerTestCase`.
- `git diff --check` passed.

Android build, packaging, installation, device, and certificate validation remain with VR48 as agreed. All submitted changes are platform-neutral and do not modify Android build scripts.
