### PR TITLE
Fix rendering and QuantBot production; enable macOS releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,20 +101,25 @@ jobs:
           path: build/*.zip
 
   build-macos:
-    # Optional: set the repository variable ENABLE_MACOS_BUILD=true when a
-    # compatible self-hosted runner is online.
-    # Self-hosted on Stefan's MacBook (8-core arm64) with a warm vcpkg binary
-    # cache. GitHub's free hosted macos-14 runner is a 3-core box that took
-    # ~70 min per cold build (and its 60-min cap killed a run); this machine
-    # builds in ~10 min. The DMG is ad-hoc signed, so no signing certs needed.
-    runs-on: [self-hosted, macOS, ARM64]
+    # The extra label keeps unrelated self-hosted Macs from accepting release
+    # jobs. Pull requests never run here because this is a persistent machine
+    # with repository access and a warm dependency cache.
+    runs-on: [self-hosted, macOS, ARM64, dunecity-builder]
     needs: [verify-version]
-    if: always() && vars.ENABLE_MACOS_BUILD == 'true' && (needs.verify-version.result == 'success' || needs.verify-version.result == 'skipped')
+    if: |
+      always() &&
+      github.event_name != 'pull_request' &&
+      vars.ENABLE_MACOS_BUILD == 'true' &&
+      (needs.verify-version.result == 'success' || needs.verify-version.result == 'skipped')
     timeout-minutes: 60
+    permissions:
+      contents: read
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: "8"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Clean previous build
         run: rm -rf build
@@ -123,7 +128,7 @@ jobs:
       # from source; ensure the autotools toolchain + nasm are present
       # (idempotent — already installed on the runner).
       - name: Install build deps
-        run: brew install autoconf autoconf-archive automake libtool pkg-config nasm ninja || true
+        run: brew install autoconf autoconf-archive automake cmake libtool pkg-config nasm ninja
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
@@ -138,22 +143,30 @@ jobs:
           echo "VCPKG_BINARY_SOURCES=clear;files,$HOME/.cache/vcpkg/archives,readwrite" >> "$GITHUB_ENV"
 
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
+        run: >-
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
+          -DVCPKG_TARGET_TRIPLET=arm64-osx
 
       - name: Build
-        run: cmake --build build --config Release --parallel
+        run: cmake --build build --config Release --parallel "$CMAKE_BUILD_PARALLEL_LEVEL"
 
       - name: Create DMG Installer
         run: |
           cd build
-          cmake --install . --prefix install --config Release
           cpack -G DragNDrop -C Release
+
+      - name: Verify DMG
+        run: bash scripts/verify-macos-dmg.sh build/DuneCity-*-macOS.dmg
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
           name: DuneCity-macOS-DMG
           path: build/*.dmg
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Notify Discord
         if: always() && env.DISCORD_WEBHOOK != ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md — DuneCity
+
+## Read first
+
+1. **`HANDOVER.md`** — state of the current, uncommitted work: what was fixed, what is still
+   open, and the diagnostics already built into `build/bin/dunecity.app`. Start here.
+2. `CLAUDE.md` — the standing architecture constraints (2x2 zone footprint, roads as tile flags,
+   global power, versioning rules). Its `~/development/dunecity` and `/Users/stefanclaw/...`
+   paths refer to a different machine; on this Mac the checkout is `~/Documents/projects/dunecity`.
+3. `ARCHITECTURE.md` and `docs/dunecity-current-architecture.md` for deeper background.
+
+## Build on this Mac (macOS, Apple silicon, Homebrew — no vcpkg, no Xcode)
+
+```bash
+brew install cmake ninja sdl2_mixer sdl2_ttf miniupnpc catch2
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=/opt/homebrew -DDUNECITY_BUILD_TESTS=ON
+cmake --build build --parallel 10
+ctest --test-dir build --output-on-failure
+```
+
+`-DCMAKE_PREFIX_PATH=/opt/homebrew` is required or configure fails on miniupnpc.
+Run tests through `ctest`, never `./build/bin/dunelegacy_tests` directly — ctest supplies
+`DUNE_CITY_SOURCE_DIR` and `DUNECITY_DATADIR`, without which ~50 tests silently misbehave.
+Ignore the tracked `build2/`, `build_phase4/`, `build.bad/`, `buildtests/` trees; they are stale
+and belong to another machine.
+
+Baseline test result: 362 passed, 2 failed, 3 skipped. The two failures are pre-existing
+(`parseDouble` accepts `"nan"`); see `HANDOVER.md` §1.
+
+## Runtime paths
+
+- Config: `~/Library/Application Support/Dune City/Dune City.ini`
+- Log: `~/Library/Application Support/Dune City/Dune City.log` (truncated on every launch)
+- Mod overrides: `~/Library/Application Support/Dune City/mods/<mod>/`
+
+## Working agreement
+
+- Do not commit or push without being asked. The tree currently carries a large body of
+  uncommitted work described in `HANDOVER.md`.
+- Any release build, tag, or CI-triggering push must include the version bump in the same commit
+  (`scripts/bump-version.sh`); CI verifies the tag against the source metadata.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 # Project name and version
-project(DuneCity VERSION 1.0.535 LANGUAGES C CXX)
+project(DuneCity VERSION 1.0.536 LANGUAGES C CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,5 +1,32 @@
 # Handover — DuneCity session, 2026-09-06
 
+## Codex follow-up: repair/factory balance, 2026-09-06
+
+Current-game evidence saved in `build/ai-balance-before.log`: Neutral ordered
+its fourth repair yard with two busy heavy factories and later held ~18k credits;
+Mercenary ordered its sixth repair yard with two factories. Some heavy factories
+were being built, but the city cash target added only one per 10k credits while
+repair yards grew unconditionally with army value (one per 6k).
+
+`QuantBotBuildPolicy` now targets an extra city heavy factory per 5k credits above
+2k working capital, still taking the larger income target and capping at eight.
+Extra repair yards require all existing yards busy, count queued yards as spare
+capacity, and cap at ceil(completed heavy factories / 2), minimum one, maximum four.
+The first-yard tech rule remains. City factory expansion uses actual build-list
+availability without the additional policy-only repair-yard/IX prerequisite;
+classic-mode factory prerequisites remain. Power recovery and economy seeding
+still precede expansion, and military/unit limits still stop factory expansion.
+
+Added 30-game-second per-CY `BUILD-BALANCE` logs (HF/RY completed/queued/busy,
+factory target/reason, repair cap, estimated tax income, power) and `BUILD-CHOICE`
+logs alongside the existing no-site/rejected-order diagnostics.
+
+Local app rebuilt at `build/bin/dunecity.app`, source version 1.0.535 checked
+consistent; no version bump, commit, or push. `build/ai-balance-tests.log` reports
+372 passed, the same two pre-existing parseDouble("nan") failures, three skipped.
+The running game must be saved, quit, and reloaded in this rebuilt app before
+these changes and new logs take effect. Live post-change validation is pending.
+
 ## Codex follow-up: QuantBot production and civic graphics, 2026-09-06
 
 User reported Brutal QuantBot's heavy factory idle, one construction yard

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,367 @@
+# Handover — DuneCity session, 2026-09-06
+
+## Codex follow-up: QuantBot production and civic graphics, 2026-09-06
+
+User reported Brutal QuantBot's heavy factory idle, one construction yard
+repeatedly building residential lots, the other idle, and building graphics
+appearing in other places. Preserved live evidence in `build/quantbot-before.log`.
+Bots held roughly 50–60k credits with military values far below their configured
+80k limit. Logs repeatedly selected Heavy Factory, then deduplicated Palace,
+then entered `PROACTIVE: Building Residential Zone`. The running game's user
+override enables `Only One Palace`; the screenshot also showed `ALREADY BUILT`.
+
+Verified production causes and fixes:
+
+- QuantBot's city palace target ignored `onlyOnePalace` and mixed internal and
+  displayed population. BuilderBase rejected the extra palace, while QuantBot
+  counted the rejected order and reserved the entire production loop for it.
+  The planner now respects the option and the documented 30k displayed-population
+  scaling; counts update only on accepted normal construction orders. Subsequent
+  yards re-evaluate palace/IX counts including queued orders.
+- Strategic saving now reserves the item's price and allows factories to spend
+  the remaining cash. An unplaceable strategic structure does not reserve funds.
+- Removed unconditional residential fallback. City bootstrap, ongoing zoning,
+  and idle-yard fallback rank R/I/C demand and count balance, trying another
+  demanded type if the first cannot be placed. The fallback respects power.
+- Heavy factory expansion considers both income and surplus cash, bounded at
+  eight factories, and stops expansion when the military-value or ground-unit
+  limit is reached. Corrected siege-tank budget accounting.
+- Concrete placement plans are now per construction yard. The old shared FIFO
+  could send one yard to the other's planned location. The old serialized list
+  remains for save-layout compatibility; runtime per-yard plans rebuild after
+  load. Placement cache clears after placing a structure.
+- Construction-yard status logging is throttled per bot rather than using
+  shared static state across all yards/houses. HF/CY diagnostics identify the
+  builder, queue, hold state, budget and relevant limits/reserves.
+
+Graphics cause: a zone's civic overlay selected a 1x1 hospital/church texture,
+but StructureBase's per-draw refresh replaced it with the 4x4 residential atlas
+using the unchanged graphicID. The full atlas then rendered over neighbouring
+lots. ZoneStructure now updates graphicID with the civic image and restores the
+zone ID and atlas dimensions together when the overlay clears or density is zero.
+
+Build: `build/bin/dunecity.app` rebuilt successfully; source version remains
+1.0.534, uncommitted. `build/quantbot-fix-tests.log`: 370 passed, the same two
+pre-existing parseDouble("nan") failures, three skipped. New tests cover the
+production policies and the civic texture-refresh contract. Live confirmation
+after saving/restarting/reloading the user's current game is still pending.
+
+## Codex follow-up: credits root cause confirmed, 2026-09-06
+
+The live diagnostic fired with `dst=2515,135`, `output=2560x1600`,
+`logical=0x0`, `target=screenTexture`, and `copy=0`. The active texture is
+960x600. This supersedes the stale-texture hypothesis in §3.1: texture creation
+already follows the final logical-size adjustment.
+
+On this Mac's sdl2-compat backend, binding the texture clears the logical size,
+but `SDL_GetRendererOutputSize` still returns the window's native pixel size.
+`getRendererSize()` consequently positioned dynamically right-aligned elements
+off the target, while the sidebar retained its correct construction-time position.
+The fix in `include/misc/DrawingRectHelper.h` queries the active texture when
+there is no logical size, falling back to output size only for the backbuffer.
+
+`tests/RendererSizeTestCase.cpp` covers target switching, credits positioning,
+and backbuffer restoration. It uses software rendering by default; run through
+`DUNECITY_RENDERER_TEST_GPU=1 ctest --test-dir build --output-on-failure` to
+exercise the native HiDPI backend. Before the fix the native test reproduced
+`getRendererWidth() == 2560` where 960 was expected. The rebuilt app is at
+`build/bin/dunecity.app`. Both software and native-backend suite runs now report
+363 passed, the same 2 pre-existing `parseDouble("nan")` failures, and 3 skipped.
+Logs are `build/credits-tests-before.log`, `build/credits-tests-after-native.log`,
+and `build/credits-tests-after-software.log`. The temporary constructor/blit
+diagnostics were removed; the signed digit arithmetic is retained. The currently
+open game is still the previous executable and needs a restart for visual
+confirmation. No commit or release/version change has been made.
+
+The original handover below is retained as historical context.
+
+Written by Claude Code for the next agent (Codex). Everything below is **uncommitted**
+in the working tree on `main` at `24b57ff`, version `1.0.534` (all three version files agree).
+
+23 files changed, ~554 insertions. Nothing has been committed, tagged or pushed.
+
+---
+
+## 1. Build environment on this Mac (this was not documented before)
+
+Host is Stefan's MacBook Air (`Stefans-MacBook-Air.local`, Apple M5, 10 cores, macOS 26.5.2).
+The repo docs describe vcpkg (CI) and a Windows laptop; neither applies here. **Homebrew, no
+vcpkg, no Xcode** — Command Line Tools clang 21 is enough.
+
+```bash
+brew install cmake ninja sdl2_mixer sdl2_ttf miniupnpc catch2
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=/opt/homebrew -DDUNECITY_BUILD_TESTS=ON
+cmake --build build --parallel 10        # ~4 min cold -> build/bin/dunecity.app
+cmake --build build --target dmg         # -> build/DuneCity-1.0.534-macOS.dmg
+ctest --test-dir build --output-on-failure
+```
+
+Gotchas:
+
+- `-DCMAKE_PREFIX_PATH=/opt/homebrew` is **required**, otherwise `find_library(MINIUPNPC_LIBRARY …)`
+  in `src/CMakeLists.txt` fails and configure dies on a NOTFOUND link item.
+- Homebrew `sdl2` is an alias of `sdl2-compat` (SDL2 API over SDL3). It works.
+- `discord-rpc` is not in Homebrew and is optional in CMake, so Discord presence is compiled out.
+- libcurl comes from the macOS SDK.
+- Use `build/`. The tracked `build2/`, `build_phase4/`, `build.bad/`, `buildtests/` are stale
+  CMake trees from claw.local (`CMAKE_HOME_DIRECTORY=/Users/stefanclaw/development/dunecity`).
+  `CLAUDE.md`'s `~/development/dunecity` paths are claw.local's, not this machine's.
+- This build links `/opt/homebrew` dylibs, so the app and its DMG are **not portable**.
+  The distributable DMG still comes from CI's vcpkg static build.
+- The bundle `Info.plist` shows version `0.01` because `IDE/xCode/Info.plist` uses Xcode
+  `$(…)` variables CMake does not substitute. Real version: `build/include/config.h` and the
+  log line `Starting DuneCity <version>`.
+
+**Always run the test suite through `ctest`, never the binary directly.** `tests/CMakeLists.txt`
+passes `DUNE_CITY_SOURCE_DIR` and `DUNECITY_DATADIR` via `set_tests_properties(... ENVIRONMENT ...)`;
+running `./build/bin/dunelegacy_tests` by hand silently skips ~50 source-reading tests and
+produces bogus failures.
+
+### Test status
+
+`ctest` → **362 passed / 2 failed / 3 skipped** (367 cases, 2422 assertions).
+
+Both failures are **pre-existing, not caused by this session**:
+
+- `tests/GenericNinthHouseRegressionTestCase.cpp:71` and `:130` — `parseDouble` accepts the
+  string `"nan"` on macOS (`ModMentatConfig::parseDouble` / `CustomHouseConfig::parseDouble`
+  in `include/mod/`). `std::stod`/`strtod` parse `nan` on this libc; the test expects rejection.
+  Fix by rejecting non-finite results (`std::isfinite`) in both headers.
+
+Separately, `tests/Dune2RAssetManagerTestCase.cpp` **segfaults non-deterministically** (line 32,
+52 or 72 depending on the run) — 6 of 6 isolated runs crashed. It passes under `ctest` when the
+whole suite runs, so it is order- or environment-dependent. This is a real bug and was **not**
+investigated. An lldb backtrace needs a one-time macOS debugger authorisation that could not be
+granted headlessly.
+
+---
+
+## 2. What was changed (all uncommitted)
+
+### 2.1 Windowed resolution changes were ignored — FIXED, verified
+
+`setVideoMode` in `src/main.cpp` snapped the requested window size to
+`SDL_GetClosestDisplayMode` before creating the window. That is exclusive-fullscreen logic and
+the game only ever uses `SDL_WINDOW_FULLSCREEN_DESKTOP`. On a Retina Mac SDL only offers
+low-density modes as candidates, so 1280x800 → 1920x1200, 1440x900 → 1920x1200,
+1024x768 → 2048x1326. The window was also created larger than the desktop (1710x1107 points).
+
+Now: the requested size is used as-is, clamped to `SDL_GetDisplayUsableBounds` in windowed mode,
+floor `SCREEN_MIN_WIDTH/HEIGHT`. The logical size derives from what is actually presented (the
+desktop in fullscreen, the window otherwise), so the saved windowed size survives a fullscreen
+round trip. New log line: `Window: <req> requested, <got> created (<mode>), <w>x<h> pixels`.
+
+`OptionsMenu::determineAvailableScreenResolutions` now drops modes larger than
+`SDL_GetDisplayBounds` (the native 2880x1864 panel mode could never be used).
+
+### 2.2 Black bars and mushy text in windowed mode — FIXED, verified
+
+Two causes. The `DISPLAY` screen's "SCREEN SHAPE" forced the logical width to 4:3 or 16:9 while
+the height was pinned by the interface preset, so a 4:3 screen sat inside a 16:10 window. And
+`SDL_HINT_VIDEO_HIGHDPI_DISABLED` was set to `"1"` (present since the initial commit), so a
+1440x900 window had a 1440x900 pixel surface and 600 logical rows were scaled 1.5x.
+
+Now: `SDL_WINDOW_ALLOW_HIGHDPI` is set on desktop, the HiDPI-disable hint is gone, and the
+logical width follows the window's shape via a new `interfaceWidthForShape()` in `src/main.cpp`.
+Only the height stays a preset. The SCREEN SHAPE row is hidden on desktop in
+`src/Menu/DisplayMenu.cpp` (Android keeps the old behaviour) and that menu's layout was compacted.
+
+Mouse mapping under sdl2-compat was verified with a standalone probe before enabling HiDPI:
+events arrive in logical coordinates correctly.
+
+**Caveat discovered later and NOT addressed** — see §3.1: `Game::renderFrame()` renders
+everything into `screenTexture` at the logical size and then upscales, so the HiDPI surface does
+not actually buy sharpness yet.
+
+### 2.3 "Multiple players per house" forgotten — FIXED
+
+New `settings.general.multiplePlayersPerHouse`, persisted as
+`[General] Multiple Players Per House` in `Dune City.ini`. The checkbox in
+`src/Menu/CustomGameMenu.cpp` seeds from it and writes on toggle. Also written by
+`OptionsMenu::saveConfiguration2File` and included in the generated default config in `main.cpp`.
+
+### 2.4 Second player slot per house missing — FIXED (was a regression)
+
+Came in with commit `5a172ce` "Import Tornie 1.0.520 source snapshot" (2026-07-15), not with any
+DuneCity fix. `CustomGamePlayers`'s constructor force-disabled
+`setMultiplePlayersPerHouse(false)` for every custom game, calling the second slot "unusable",
+and `onNext()` rejected two players in one house as `bTwoPlayersInSameHouse`. Both removed. The
+newer duplicate-house and duplicate-colour checks were kept. The slot code itself is byte-identical
+to v1.0.359.
+
+**Not verified in play.** Stefan has not yet started a co-op game with two players in one house.
+
+### 2.5 Credits SFX on by default — FIXED
+
+Defaulted to off in all three places: the `getBoolValue` fallback in `main.cpp`, the generated
+default config (which previously omitted the key entirely and so inherited `true`), and the
+shipped template `config/Dune City.ini`. Existing configs keep the player's own value.
+
+### 2.6 Zones placed on top of each other — PARTIALLY FIXED, needs play testing
+
+`House::placeStructure`'s pre-placement check only tested `hasAGroundObject()` and never
+`hasCityZone()`. It now refuses both and logs
+`placeStructure: refused zone item <id> for house <h> at (x,y): tile (x,y) already belongs to a zone`.
+
+**This log line has already fired once** in Stefan's session (`item 20 for house 0 at (24,13)`),
+which proves the guard works and that something is still *requesting* overlapping placements.
+Whether visible overlap remains is unconfirmed.
+
+`Game::load` now re-attaches every zone structure to its 2x2 footprint after `objectManager.load`,
+because zones from older saves could come back without owning their tiles. It logs
+`Loaded game: re-attached N zone tiles, M zone tiles overlap another object`.
+
+### 2.7 Zone road frontage and sand placement — DONE, needs play testing
+
+In `src/players/QuantBot.cpp`, city-mode zone placement (`findPlaceLocation`, guarded by
+`cityZonePlacement`):
+
+- The per-adjacent-tile `locationScore += 10` compact-base bonus is suppressed for zones. That
+  bonus is what produced solid packed blocks.
+- New `alignedWithNeighbouringZone()` gives +50 for continuing an existing row or column, either
+  touching or exactly one road tile apart.
+- New `wouldLandlockNeighbouringZone()` rejects a lot that would take a neighbour's last open side.
+- Small bonus per sand/dunes tile under the lot so rock stays free for Dune structures.
+
+Sand rule, implemented in four places that all had their own copy of the terrain test:
+
+- `DuneCity::isCityZoneTerrain()` (new, `include/dunecity/CityConstants.h`) — rock, slab, sand or dunes.
+- `Map::okayToPlaceStructure(..., itemID)` — zones use the new predicate plus an `anchoredTiles > 0`
+  requirement; other city-only structures keep the strict rock/slab rule.
+- `ZoneStructure::canBePlacedAt` — same.
+- `Game.cpp`'s placement preview — same, with `zoneFootprintAnchored` computed once per footprint.
+
+`tests/ZoneStructureTestCase.cpp` had a source-text test asserting the old strict rule; it was
+updated to assert the new one.
+
+### 2.8 Game options only saved from the Options screen — FIXED
+
+There were **three** layers, not two: `[Game Options]` in the main config, then the active mod's
+`GameOptions.ini` overlaid on top. The Dune City mod's file lists every key, so it always won —
+which is why changing a default under Options never stuck either.
+
+New helpers in `src/globals.cpp` / `include/globals.h`: `userGameOptionsSection()`,
+`writeGameOptionsToConfig()`, `applyGameOptionsFromConfig()`, `saveGameOptionsAsDefaults()`.
+The player's choices are stored per mod in the main config as `[Game Options <modname>]` and
+layered over the mod's defaults in `ModManager::loadEffectiveGameOptions`.
+
+**The mod's own `GameOptions.ini` is deliberately left untouched** — `ModManager::updateChecksums`
+hashes it for the multiplayer config-sync check, so writing into it would make two players with
+different preferences fail to sync.
+
+Every Game Options window now calls the helper on close: Options ("Change…"), the Custom Game
+lobby, Skirmish, and the campaign house choice. `Restore Config Defaults` removes the override
+section and its message was updated to say so. The `City Effects` key, which the Options screen
+never persisted, is included.
+
+### 2.9 Production stall diagnostics — ADDED
+
+`BuilderBase::updateProductionProgress` had a silent branch: if on hold, at the unit limit, or at
+zero credits, nothing happened and nothing was reported. It now logs every 10 s with the reason
+and a credit breakdown, and posts a ticker message every 30 s for the unit limit and for no money.
+
+This was added for Stefan's "heavy factories aren't building" report, which is **not diagnosed**.
+Note `House::getCredits()` sums three pools (`cityCredits + storedCredits + startingCredits`) and
+QuantBot in the same house shares the human's wallet.
+
+### 2.10 macOS test link fix
+
+`tests/CMakeLists.txt` did not compile `IDE/xCode/MacFunctions.m` on APPLE, so `dunelegacy_tests`
+failed to link with `_getMacApplicationSupportFolder` undefined (from `fnkdat.cpp`). Added the
+game target's `if(APPLE)` block plus the Cocoa/Foundation/CoreFoundation frameworks.
+
+---
+
+## 3. Open items for Codex
+
+### 3.1 Credits counter shows nothing — THE MAIN OPEN BUG
+
+Reported repeatedly: the credits box below the radar renders empty in-game.
+
+**What has been ruled out**, from a diagnostic already in the running build
+(`Interface: credits digits texture 80x8, sidebar 144x600 at x=816, credits 20000`):
+
+- The digits texture loads fine: 80x8, i.e. 10 glyphs of 8x8 from `SHAPES.SHP` frames 2..11.
+- The credits value is correct (20000 at construction).
+- The geometry is correct. Logical screen 960x600, sidebar 144 wide at x=816. `PictureFactory`
+  blits `creditsBorder` (63x13) at sidebar-relative (46,132) → global 862..925 x 132..145.
+  `GameInterface` draws digits at x = 816+49+(6-n+i)*10, y=135, 8x8 → 875..923 x 135..143.
+  That is inside the box.
+- Palette is not the cause. The glyphs use only indices 31, 81 and 90; `Custom_IBM.PAL` in
+  `Tornie.PAK` leaves all three identical to `IBM.PAL`, and `applyCustomPaletteRuntimeHouseRamps`
+  only touches 52..59.
+- Draw order is fine: credits are drawn after `Window::draw`, and the radar occupies y=0..132.
+- `drawCityStatsOverlay()` is the only thing drawn afterwards in the same function and
+  `showCityStatsOverlay` defaults to false.
+- No `SDL_RenderSetClipRect` exists anywhere in the in-game render path.
+
+**One real bug was found and fixed while looking**: `NumDigits` is `std::string::size_type`
+(unsigned), so `6 - NumDigits` wrapped around for credits with more than 6 digits and threw every
+glyph far off-screen. Now cast to `int`. This is **not** the reported symptom (5-digit credits
+were affected too), but it would have bitten at 1,000,000 credits.
+
+**A one-shot draw-time diagnostic is in the build at `build/bin/dunecity.app` (12:53).** On the
+next in-game frame it logs one line to `~/Library/Application Support/Dune City/Dune City.log`:
+
+```
+Credits blit: value=… digits=… src=… dst=… copy=… output=…x… logical=…x… clip=… blend=… alpha=… rgbMod=… target=…
+```
+
+Start a game and grep for `Credits blit:`. That line settles it: whether `SDL_RenderCopy`
+returns non-zero, whether a clip rect is active, whether the texture is fully transparent
+(`alpha=0`) or colour-modulated to nothing, and which render target is bound.
+
+**Strongest remaining hypothesis**, worth checking first: `Game::renderFrame()` sets the render
+target to `screenTexture` (created at `settings.video.width x settings.video.height`), draws
+everything, then copies it to the backbuffer. If `screenTexture` is stale or smaller than the
+current logical size after a resolution change, the sidebar's right-hand columns would fall
+outside it. `setVideoMode` recreates it, but check that every path that changes
+`settings.video.width/height` also recreates `screenTexture` — the interface-preset override in
+`setVideoMode` runs *after* the window is created and could leave the two out of step.
+
+### 3.2 Budget window looks blurry
+
+Not reproduced. `CityBudgetWindow` uses the same `Label`/`Window` pipeline as the sidebar text
+that renders crisply, and the screenshot supplied was scaled ~1.3x, which would explain it.
+
+If it is real, the likely cause is §3.1's `screenTexture`: the whole frame is composited at
+960x600 and then upscaled by ~2.67x to 2560x1600 with nearest-neighbour
+(`SDL_HINT_RENDER_SCALE_QUALITY` is `"0"`). Non-integer nearest scaling gives uneven pixel
+doubling that reads as mushy. Rendering the UI at native density, or choosing an integer scale,
+would fix it — but that is a real change to the render architecture, not a one-liner.
+
+### 3.3 Heavy factories not building
+
+Not diagnosed. The diagnostics from §2.9 are in the build; play a game and grep the log for
+`Production stalled:`. Check the unit limit first: `House::isGroundUnitLimitReached()` counts
+`numGroundUnit + (numItem[Unit_Soldier]+2)/3 + (numItem[Unit_Trooper]+2)/3 >= maxUnits`, and
+Stefan's Game Options screenshot shows "Override max. number of units" **ticked with a value of 0**.
+`INIMapLoader` treats an override `>= 0` as authoritative, and `maxUnits == 0` is documented as
+"unlimited" in `House.h` — verify that 0 really means unlimited on every path rather than
+"no units allowed", because the override is applied before that comment's assumption.
+
+### 3.4 Verification still owed
+
+Nothing in §2.4, §2.6 or §2.7 has been confirmed in actual play. The city-placement changes in
+particular are scoring heuristics and need a game watched for a few minutes.
+
+---
+
+## 4. Before committing
+
+`CLAUDE.md` requires the version bump in the same commit as any release work, and CI verifies
+that the tag matches. This session did **not** bump anything; the tree is still 1.0.534, which is
+already tagged. Decide on 1.0.535 and run `scripts/bump-version.sh 1.0.535` before tagging.
+
+Suggested split, since these are unrelated fixes:
+
+1. Windowed resolution + HiDPI + DISPLAY menu (§2.1, §2.2)
+2. Custom game lobby: remembered checkbox + restored second slot (§2.3, §2.4)
+3. Credits SFX default off (§2.5)
+4. City zone placement: overlap guard, road frontage, sand (§2.6, §2.7)
+5. Game option defaults saved from any pre-game screen (§2.8)
+6. Diagnostics: production stalls, credits blit, macOS test link (§2.9, §2.10)
+
+The credits-blit block in `src/GameInterface.cpp` is a temporary probe — remove it once §3.1 is
+solved, but keep the unsigned-arithmetic fix.

--- a/IDE/xCode/Info.plist
+++ b/IDE/xCode/Info.plist
@@ -5,23 +5,23 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
 	<string>dunecity.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.01</string>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.01</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>NSMainNibFile</key>

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ cmake --build build -j$(sysctl -n hw.ncpu)
 open build/bin/dunecity.app
 ```
 
+Release DMGs are built on the self-hosted Apple Silicon GitHub Actions runner.
+See [docs/macos-release-runner.md](docs/macos-release-runner.md) for runner setup,
+artifact verification, and the release sequence.
+
 ### Windows
 
 ```bash

--- a/config/Dune City.ini
+++ b/config/Dune City.ini
@@ -55,7 +55,7 @@ Play Music = true
 Music Volume = 64           # Volume between 0 and 128
 Play SFX = true
 SFX Volume = 64             # Volume between 0 and 128
-Play Credits SFX = true     # Play sound when credits change (harvester deliveries, spending credits)
+Play Credits SFX = false    # Play sound when credits change (harvester deliveries, spending credits)
 
 [Network]
 ServerPort = 28747

--- a/docs/macos-release-runner.md
+++ b/docs/macos-release-runner.md
@@ -1,0 +1,77 @@
+# macOS release runner
+
+DuneCity's macOS DMG is built by a repository-level self-hosted GitHub Actions
+runner. Both the MacBook and Mac mini can use the `dunecity-builder` label; an
+online, idle runner claims each job.
+
+The workflow deliberately excludes pull requests. A self-hosted runner executes
+repository code on the host, so only pushes by maintainers, version tags, and
+manual workflow runs may use it.
+
+## One-time host setup
+
+1. Install the native tools:
+
+   ```bash
+   xcode-select --install
+   brew install autoconf autoconf-archive automake cmake libtool pkg-config nasm ninja
+   ```
+
+2. In GitHub, open **Settings → Actions → Runners → New self-hosted runner** for
+   `VR48/dunecity`. Install the ARM64 macOS runner outside the repository and use
+   these configuration values:
+
+   ```text
+   Runner group: Default
+   Name: dunecity-macbook-air or dunecity-mac-mini
+   Extra label: dunecity-builder
+   Work folder: _work
+   ```
+
+3. Install and start its LaunchAgent from the runner directory:
+
+   ```bash
+   ./svc.sh install
+   ./svc.sh start
+   ./svc.sh status
+   ```
+
+4. Set the repository Actions variable `ENABLE_MACOS_BUILD` to `true`. Set it to
+   `false` before taking every Mac runner offline for an extended period, or
+   release workflows will wait for the Mac job until its timeout.
+
+The service runs as the user that configured it. Keep that account logged in
+after reboot and disable automatic sleep while it is acting as a runner.
+
+## What the job produces
+
+The runner builds the ARM64 app with vcpkg, stages non-system dylibs inside
+`dunecity.app/Contents/Frameworks`, applies an ad-hoc signature, and creates
+`DuneCity-X.Y.Z-macOS.dmg`. The verification step mounts the DMG and checks:
+
+- app metadata and version match the source version;
+- the executable has an ARM64 slice;
+- no Homebrew, user-directory, or vcpkg build paths remain;
+- the app bundle has a valid code signature and required game data;
+- the drag-to-Applications link exists.
+
+The DMG is uploaded as the `DuneCity-macOS-DMG` workflow artifact. On a `vX.Y.Z`
+tag, the existing release job attaches it to the GitHub Release and updates the
+dunelegacy.com download links after publishing.
+
+## Release sequence
+
+Run a manual workflow on the release commit before tagging it. Once its macOS
+job passes:
+
+```bash
+scripts/bump-version.sh X.Y.Z
+git add CMakeLists.txt include/config.h vcpkg.json
+git commit -m "release: prepare DuneCity X.Y.Z"
+git push origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The source version must be committed before the tag. The tag workflow rejects a
+version mismatch and publishes the website only after the GitHub Release exists.

--- a/include/DataTypes.h
+++ b/include/DataTypes.h
@@ -167,6 +167,7 @@ public:
         std::string     language;           ///< Language code: "en" = English, "fr" = French, "de" = German
         int             scrollSpeed;        ///< Scroll speed in pixels
         bool            showTutorialHints;  ///< If true, tutorial hints are shown during the game
+        bool            multiplePlayersPerHouse = false; ///< Custom game lobby: allow two players per house (remembered across games)
     } general;
 
     class VideoClass {

--- a/include/Menu/CustomGameMenu.h
+++ b/include/Menu/CustomGameMenu.h
@@ -54,6 +54,7 @@ private:
     void onCancel();
     void onLoad();
     void onGameOptions();
+    void onMultiplePlayersPerHouseChange();
     void onMapTypeChange(int buttonID);
     void onMapListSelectionChange(bool bInteractive);
 

--- a/include/config.h
+++ b/include/config.h
@@ -16,7 +16,7 @@
  */
 
 #ifndef VERSION
-    #define VERSION "1.0.535"
+    #define VERSION "1.0.536"
 #endif
 
 #ifndef PACKAGE

--- a/include/dunecity/CityConstants.h
+++ b/include/dunecity/CityConstants.h
@@ -50,6 +50,15 @@ inline bool isCityBuildableTerrain(uint32_t terrain) {
     return terrain == Terrain_Rock || terrain == Terrain_Slab;
 }
 
+// Zones may spill onto sand: every tile must be rock, slab, sand or dunes,
+// and the footprint must keep at least one rock or slab tile so the lot stays
+// anchored to the buildable substrate. Spice, blooms and mountains never
+// qualify.
+inline bool isCityZoneTerrain(uint32_t terrain) {
+    return terrain == Terrain_Rock || terrain == Terrain_Slab
+        || terrain == Terrain_Sand || terrain == Terrain_Dunes;
+}
+
 inline int getCityBuildTime(int itemID, int configuredBuildTime,
                             int concreteBuildTime, int policeBuildTime) {
     if (itemID == Structure_Road) {

--- a/include/globals.h
+++ b/include/globals.h
@@ -164,6 +164,18 @@ SDL_Color getHouseColorSDL(int colorSlot, int shadeOffset = 3);
 Uint32 getHouseColorRGB(int colorSlot, int shadeOffset = 3);
 
 void loadCustomPalette();
+
+class INIFile;
+/// Config section holding the player's own game option choices for the active
+/// mod (empty for vanilla, which keeps them in [Game Options] directly).
+std::string userGameOptionsSection();
+/// Writes every game option key into the given config section.
+void writeGameOptionsToConfig(INIFile& config, const std::string& section, const SettingsClass::GameOptionsClass& options);
+/// Overlays the keys present in the given config section onto options.
+void applyGameOptionsFromConfig(const INIFile& config, const std::string& section, SettingsClass::GameOptionsClass& options);
+/// Makes options the new defaults: updates settings, the config file (base
+/// section and the per-mod override) and the effective options.
+void saveGameOptionsAsDefaults(const SettingsClass::GameOptionsClass& options);
 void applyCustomPaletteRuntimeHouseRamps();
 bool isHouseAvailable(HOUSETYPE house);
 int getNumAvailableHouses();

--- a/include/misc/DrawingRectHelper.h
+++ b/include/misc/DrawingRectHelper.h
@@ -205,7 +205,14 @@ inline SDL_Rect getRendererSize() {
     SDL_Rect rect = {0, 0, 0, 0};
     SDL_RenderGetLogicalSize(renderer, &rect.w, &rect.h);
     if(rect.w == 0 || rect.h == 0) {
-        SDL_GetRendererOutputSize(renderer, &rect.w, &rect.h);
+        // Binding a texture can clear the logical size. sdl2-compat still
+        // reports the window's pixel dimensions as the renderer output then,
+        // so query the active target to keep right-aligned UI inside it.
+        if(SDL_Texture* target = SDL_GetRenderTarget(renderer)) {
+            SDL_QueryTexture(target, nullptr, nullptr, &rect.w, &rect.h);
+        } else {
+            SDL_GetRendererOutputSize(renderer, &rect.w, &rect.h);
+        }
     }
     return rect;
 }

--- a/include/players/QuantBot.h
+++ b/include/players/QuantBot.h
@@ -126,6 +126,9 @@ private:
                                     const QuantBotConfig& config);
 
     std::list<Coord> placeLocations;    ///< Where to place structures
+    // Runtime-only plans; the legacy list above remains in the save layout.
+    // After loading, each yard safely finds positions for its own queued items.
+    std::map<Uint32, std::list<Coord>> builderPlaceLocations;
     OrnithopterStrikeTeam ornithopterStrikeTeam;
     std::unordered_map<Uint32, Coord> placementCache; ///< Per-build-cycle cache for findPlaceLocation results
 

--- a/include/players/QuantBotBuildPolicy.h
+++ b/include/players/QuantBotBuildPolicy.h
@@ -49,8 +49,26 @@ inline int desiredHeavyFactories(bool citySim, int creditsPerSecond, int credits
     // Income sustains normal expansion; a large unspent treasury can fund
     // additional capacity. Bound expansion so a busy queue cannot grow it forever.
     const int incomeTarget = 1 + std::max(0, creditsPerSecond) / 50;
-    const int cashTarget = 1 + std::max(0, credits) / (citySim ? 10000 : 4000);
+    // Keep working capital for units/power, then add a city production lane
+    // per 5000 surplus credits instead of waiting for another 10000.
+    const int cashTarget = 1 + (citySim ? spendableCredits(credits, 2000) / 5000
+                                      : std::max(0, credits) / 4000);
     return std::clamp(citySim ? std::max(incomeTarget, cashTarget) : cashTarget, 1, 8);
+}
+
+inline int repairYardCap(int heavyFactories) {
+    // Repair is support capacity: at most one yard per two heavy factories.
+    return std::clamp((heavyFactories + 1) / 2, 1, 4);
+}
+
+inline bool needsExtraRepairYard(int yardsIncludingQueued, int busyYards,
+                                int heavyFactories, int militaryValue) {
+    // A queued yard counts as spare capacity, preventing multiple CYs from
+    // expanding repair simultaneously. The first yard has its own tech rule.
+    return yardsIncludingQueued > 0
+        && busyYards >= yardsIncludingQueued
+        && yardsIncludingQueued < repairYardCap(heavyFactories)
+        && militaryValue > yardsIncludingQueued * 6000;
 }
 
 } // namespace QuantBotBuildPolicy

--- a/include/players/QuantBotBuildPolicy.h
+++ b/include/players/QuantBotBuildPolicy.h
@@ -1,0 +1,57 @@
+#ifndef QUANTBOT_BUILD_POLICY_H
+#define QUANTBOT_BUILD_POLICY_H
+
+#include <data.h>
+#include <SDL_stdinc.h>
+#include <Definitions.h>
+#include <algorithm>
+#include <array>
+
+namespace QuantBotBuildPolicy {
+
+inline int palaceTarget(bool onlyOnePalace, bool citySim, int displayedPopulation) {
+    return onlyOnePalace || !citySim ? 1 : 1 + std::max(0, displayedPopulation) / 30000;
+}
+
+inline int spendableCredits(int credits, int strategicCost) {
+    return std::max(0, credits - std::max(0, strategicCost));
+}
+
+// Rank live demand against the existing 3R:1I:1C target. Callers try each
+// candidate in order so an unavailable/landlocked zone cannot stall the yard.
+inline std::array<Uint32, 3> rankZones(int residential, int commercial, int industrial,
+                                      int resDemand, int comDemand, int indDemand,
+                                      bool bootstrap) {
+    struct Candidate { Uint32 item; int count; int demand; int gap; };
+    std::array<Candidate, 3> candidates{{
+        {Structure_ZoneResidential, residential, resDemand,
+         std::max(commercial, industrial) * 3 + 3 - residential},
+        {Structure_ZoneIndustrial, industrial, indDemand, std::max(residential / 3, 1) - industrial},
+        {Structure_ZoneCommercial, commercial, comDemand, std::max(residential / 3, 1) - commercial}
+    }};
+    std::stable_sort(candidates.begin(), candidates.end(), [bootstrap](const auto& a, const auto& b) {
+        const bool missingA = bootstrap && a.count == 0;
+        const bool missingB = bootstrap && b.count == 0;
+        if(missingA != missingB) return missingA;
+        return a.gap > b.gap;
+    });
+    std::array<Uint32, 3> result{{NONE_ID, NONE_ID, NONE_ID}};
+    int index = 0;
+    for(const auto& candidate : candidates) {
+        if(candidate.demand > 0 || (bootstrap && candidate.count == 0)) {
+            result[index++] = candidate.item;
+        }
+    }
+    return result;
+}
+
+inline int desiredHeavyFactories(bool citySim, int creditsPerSecond, int credits) {
+    // Income sustains normal expansion; a large unspent treasury can fund
+    // additional capacity. Bound expansion so a busy queue cannot grow it forever.
+    const int incomeTarget = 1 + std::max(0, creditsPerSecond) / 50;
+    const int cashTarget = 1 + std::max(0, credits) / (citySim ? 10000 : 4000);
+    return std::clamp(citySim ? std::max(incomeTarget, cashTarget) : cashTarget, 1, 8);
+}
+
+} // namespace QuantBotBuildPolicy
+#endif

--- a/releases/desktop/2026-09-06-v1.0.536.md
+++ b/releases/desktop/2026-09-06-v1.0.536.md
@@ -1,0 +1,10 @@
+# DuneCity 1.0.536
+
+- Restores credits rendering and other right-aligned interface elements on
+  Retina Macs using the sdl2-compat renderer.
+- Fixes QuantBot construction-yard planning, balanced city zoning, heavy-unit
+  production, and excessive repair-yard expansion.
+- Prevents civic zone graphics from replacing neighbouring building tiles.
+- Restores multiple players per house and preserves windowed display settings.
+- Adds verified Apple Silicon DMG builds on the self-hosted macOS release
+  runner, including bundled runtime libraries and correct app metadata.

--- a/scripts/verify-macos-dmg.sh
+++ b/scripts/verify-macos-dmg.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <DuneCity-X.Y.Z-macOS.dmg>" >&2
+    exit 2
+fi
+
+DMG_PATH="$1"
+if [[ ! -f "$DMG_PATH" ]]; then
+    echo "DMG does not exist: $DMG_PATH" >&2
+    exit 1
+fi
+
+SOURCE_VERSION=$(sed -n 's/^project(DuneCity VERSION \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p' CMakeLists.txt)
+EXPECTED_NAME="DuneCity-${SOURCE_VERSION}-macOS.dmg"
+if [[ "$(basename "$DMG_PATH")" != "$EXPECTED_NAME" ]]; then
+    echo "Expected $EXPECTED_NAME, got $(basename "$DMG_PATH")" >&2
+    exit 1
+fi
+
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dunecity-dmg-verify.XXXXXX")
+MOUNT_POINT="$WORK_DIR/mount"
+mkdir -p "$MOUNT_POINT"
+MOUNTED=0
+
+cleanup() {
+    if [[ "$MOUNTED" -eq 1 ]]; then
+        hdiutil detach "$MOUNT_POINT" -quiet || hdiutil detach "$MOUNT_POINT" -force -quiet || true
+    fi
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# CPack embeds the repository license as a DMG software license agreement.
+# Accept it non-interactively so verification works in GitHub Actions.
+if ! printf 'Y\n' | PAGER=cat hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$MOUNT_POINT" \
+        >"$WORK_DIR/hdiutil-attach.log" 2>&1; then
+    tail -n 30 "$WORK_DIR/hdiutil-attach.log" >&2
+    exit 1
+fi
+MOUNTED=1
+
+APP_PATH="$MOUNT_POINT/dunecity.app"
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+EXECUTABLE="$APP_PATH/Contents/MacOS/dunecity"
+
+[[ -d "$APP_PATH" ]] || { echo "dunecity.app is missing from the DMG" >&2; exit 1; }
+[[ -L "$MOUNT_POINT/Applications" ]] || { echo "Applications link is missing from the DMG" >&2; exit 1; }
+[[ -x "$EXECUTABLE" ]] || { echo "App executable is missing or not executable" >&2; exit 1; }
+[[ -f "$APP_PATH/Contents/Resources/DUNE.PAK" ]] || { echo "DUNE.PAK is missing from app resources" >&2; exit 1; }
+
+PLIST_EXECUTABLE=$(plutil -extract CFBundleExecutable raw "$INFO_PLIST")
+PLIST_IDENTIFIER=$(plutil -extract CFBundleIdentifier raw "$INFO_PLIST")
+PLIST_SHORT_VERSION=$(plutil -extract CFBundleShortVersionString raw "$INFO_PLIST")
+PLIST_BUILD_VERSION=$(plutil -extract CFBundleVersion raw "$INFO_PLIST")
+
+[[ "$PLIST_EXECUTABLE" == "dunecity" ]] || { echo "Unexpected CFBundleExecutable: $PLIST_EXECUTABLE" >&2; exit 1; }
+[[ "$PLIST_IDENTIFIER" == "net.dunecity.DuneCity" ]] || { echo "Unexpected CFBundleIdentifier: $PLIST_IDENTIFIER" >&2; exit 1; }
+[[ "$PLIST_SHORT_VERSION" == "$SOURCE_VERSION" ]] || { echo "Short version $PLIST_SHORT_VERSION does not match $SOURCE_VERSION" >&2; exit 1; }
+[[ "$PLIST_BUILD_VERSION" == "$SOURCE_VERSION" ]] || { echo "Build version $PLIST_BUILD_VERSION does not match $SOURCE_VERSION" >&2; exit 1; }
+
+codesign --verify --deep --strict "$APP_PATH"
+
+ARCHITECTURES=$(lipo -archs "$EXECUTABLE")
+[[ " $ARCHITECTURES " == *" arm64 "* ]] || { echo "arm64 slice is missing: $ARCHITECTURES" >&2; exit 1; }
+
+NON_PORTABLE=""
+while IFS= read -r BINARY; do
+    if ! file "$BINARY" | grep -q 'Mach-O'; then
+        continue
+    fi
+
+    BAD_PATHS=$(otool -L "$BINARY" | tail -n +2 | awk '{print $1}' | \
+        grep -E '^(/Users/|/opt/homebrew/|/usr/local/)|vcpkg_installed' || true)
+    if [[ -n "$BAD_PATHS" ]]; then
+        NON_PORTABLE+="$BINARY:"$'\n'"$BAD_PATHS"$'\n'
+    fi
+done < <(printf '%s\n' "$EXECUTABLE"; find "$APP_PATH/Contents/Frameworks" -type f -print)
+
+if [[ -n "$NON_PORTABLE" ]]; then
+    echo "Bundle contains non-portable library paths:" >&2
+    printf '%s' "$NON_PORTABLE" >&2
+    exit 1
+fi
+
+echo "Verified $EXPECTED_NAME: arm64, portable dylibs, valid bundle metadata and code signature."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -778,17 +778,28 @@ elseif(APPLE)
         BUNDLE DESTINATION .
     )
 
-    # Re-codesign the installed bundle. The POST_BUILD codesign on the
-    # in-tree build is invalidated by `cmake --install` rewriting the
-    # binary's rpath, so verification fails ("code or signature have
-    # been modified") and macOS shows "dunecity.app is damaged and
-    # can't be opened." Signing the bundle at install time, after all
-    # rpath fixup is done, restores a valid ad-hoc signature. The
-    # signature is still ad-hoc (no Apple Developer ID), so first-run
-    # downloads still hit Gatekeeper, but with a valid signature the
-    # warning becomes "cannot verify developer" with an Open Anyway
-    # path instead of the unrecoverable "damaged" message.
+    # Make release bundles independent of Homebrew and vcpkg paths. CPack
+    # invokes the install rules in a staging tree, so BundleUtilities copies
+    # every non-system dylib into Contents/Frameworks and rewrites its load
+    # commands before the final signature is applied.
+    set(DUNECITY_MACOS_DEPENDENCY_DIRS "")
+    if(DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+        list(APPEND DUNECITY_MACOS_DEPENDENCY_DIRS
+            "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
+    endif()
+
+    # Re-sign last because dependency fixup changes the executable and copied
+    # libraries. The signature is ad-hoc until Developer ID credentials are
+    # added to the runner, but it is internally valid and supports Open Anyway.
     install(CODE "
+        include(BundleUtilities)
+        set(BU_CHMOD_BUNDLE_ITEMS ON)
+        message(STATUS \"Bundling macOS runtime dependencies...\")
+        fixup_bundle(
+            \"\${CMAKE_INSTALL_PREFIX}/dunecity.app\"
+            \"\"
+            \"${DUNECITY_MACOS_DEPENDENCY_DIRS}\"
+        )
         message(STATUS \"Re-codesigning installed dunecity.app...\")
         execute_process(
             COMMAND codesign --force --deep --sign - \"\${CMAKE_INSTALL_PREFIX}/dunecity.app\"

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1693,6 +1693,20 @@ void Game::drawScreen()
 
                     }
 
+                    // A zone may reach onto sand, but at least one tile must sit on rock or slab.
+                    bool zoneFootprintAnchored = !isZoneStructure(placeItem);
+                    if(!zoneFootprintAnchored && footprintInsideMap) {
+                        for(int i = xPos; i < (xPos + structuresize.x) && !zoneFootprintAnchored; i++) {
+                            for(int j = yPos; j < (yPos + structuresize.y); j++) {
+                                if(currentGameMap->tileExists(i,j)
+                                   && DuneCity::isCityBuildableTerrain(currentGameMap->getTile(i,j)->getType())) {
+                                    zoneFootprintAnchored = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
                     for(int i = xPos; i < (xPos + structuresize.x); i++) {
                         for(int j = yPos; j < (yPos + structuresize.y); j++) {
                             SDL_Texture* image;
@@ -1701,7 +1715,8 @@ void Game::drawScreen()
                             if(footprintInsideMap && withinRange && currentGameMap->tileExists(i,j)) {
                                 Tile* pTile = currentGameMap->getTile(i,j);
                                 if(isZoneStructure(placeItem)) {
-                                    tileValid = DuneCity::isCityBuildableTerrain(pTile->getType())
+                                    tileValid = zoneFootprintAnchored
+                                        && DuneCity::isCityZoneTerrain(pTile->getType())
                                         && !pTile->hasCityZone()
                                         && !pTile->hasAGroundObject();
                                 } else {
@@ -3676,6 +3691,44 @@ bool Game::loadSaveGame(InputStream& stream) {
     //load the structures and units
     logLoadStage("objects");
     objectManager.load(stream);
+
+    // Zones from older saves can come back without owning their tiles, which
+    // lets new lots be placed right on top of them. Re-attach every zone to
+    // its footprint and report anything that was off.
+    {
+        int detachedTiles = 0;
+        int overlappingTiles = 0;
+        for(StructureBase* pStructure : structureList) {
+            if(!isZoneStructure(pStructure->getItemID())) {
+                continue;
+            }
+            for(int dy = 0; dy < pStructure->getStructureSizeY(); dy++) {
+                for(int dx = 0; dx < pStructure->getStructureSizeX(); dx++) {
+                    Tile* pTile = currentGameMap->getTile(pStructure->getX() + dx, pStructure->getY() + dy);
+                    if(pTile == nullptr) {
+                        continue;
+                    }
+                    const ObjectBase* pOccupant = pTile->getNonInfantryGroundObject();
+                    if(pOccupant == pStructure) {
+                        continue;
+                    }
+                    if(pOccupant == nullptr) {
+                        pTile->assignNonInfantryGroundObject(pStructure->getObjectID());
+                        detachedTiles++;
+                    } else {
+                        overlappingTiles++;
+                        SDL_Log("Loaded game: zone %u at (%d,%d) overlaps object %u on tile (%d,%d)",
+                                pStructure->getObjectID(), pStructure->getX(), pStructure->getY(),
+                                pOccupant->getObjectID(), pStructure->getX() + dx, pStructure->getY() + dy);
+                    }
+                }
+            }
+        }
+        if(detachedTiles > 0 || overlappingTiles > 0) {
+            SDL_Log("Loaded game: re-attached %d zone tiles, %d zone tiles overlap another object",
+                    detachedTiles, overlappingTiles);
+        }
+    }
 
     logLoadStage("bullets");
     int numBullets = stream.readUint32();

--- a/src/GameInterface.cpp
+++ b/src/GameInterface.cpp
@@ -354,9 +354,12 @@ void GameInterface::draw(Point position) {
     const auto NumDigits = CreditsBuffer.length();
     SDL_Texture* digitsTex = pGFXManager->getUIGraphic(UI_CreditsDigits);
 
-    for(int i=NumDigits-1; i>=0; i--) {
+    // NumDigits is unsigned: with more than 6 digits `6 - NumDigits` wraps
+    // around and every digit lands far off-screen. Keep the arithmetic signed.
+    const int numDigits = static_cast<int>(NumDigits);
+    for(int i = numDigits - 1; i >= 0; i--) {
         SDL_Rect source = calcSpriteSourceRect(digitsTex, CreditsBuffer[i] - '0', 10);
-        SDL_Rect dest = calcSpriteDrawingRect(digitsTex, getRendererWidth() - sideBar.getSize().x + 49 + (6 - NumDigits + i)*10, 135, 10);
+        SDL_Rect dest = calcSpriteDrawingRect(digitsTex, getRendererWidth() - sideBar.getSize().x + 49 + (6 - numDigits + i)*10, 135, 10);
         SDL_RenderCopy(renderer, digitsTex, &source, &dest);
     }
 

--- a/src/House.cpp
+++ b/src/House.cpp
@@ -897,7 +897,13 @@ StructureBase* House::placeStructure(Uint32 builderID, int itemID, int xPos, int
                 // check if there is already something on this tile
                 for(int i=0;i<newStructure->getStructureSizeX();i++) {
                     for(int j=0;j<newStructure->getStructureSizeY();j++) {
-                        if((currentGameMap->tileExists(xPos+i, yPos+j) == false) || (currentGameMap->getTile(xPos+i, yPos+j)->hasAGroundObject() == true)) {
+                        const Tile* pTile = currentGameMap->tileExists(xPos+i, yPos+j) ? currentGameMap->getTile(xPos+i, yPos+j) : nullptr;
+                        if(pTile == nullptr || pTile->hasAGroundObject() || pTile->hasCityZone()) {
+                            if(pTile != nullptr && isZoneStructure(itemID)) {
+                                SDL_Log("placeStructure: refused zone item %d for house %d at (%d,%d): tile (%d,%d) %s",
+                                        itemID, houseID, xPos, yPos, xPos+i, yPos+j,
+                                        pTile->hasCityZone() ? "already belongs to a zone" : "is occupied");
+                            }
                             delete newObject;
                             return nullptr;
                         }

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -393,6 +393,8 @@ bool Map::okayToPlaceStructure(int x, int y, int buildingSizeX, int buildingSize
     }
 
     bool withinBuildRange = false;
+    const bool zoneStructure = DuneCity::isCityZoneStructure(itemID);
+    int anchoredTiles = 0;
 
     for(auto i = x; i < x + buildingSizeX; i++) {
         for(auto j = y; j < y + buildingSizeY; j++) {
@@ -406,18 +408,27 @@ bool Map::okayToPlaceStructure(int x, int y, int buildingSizeX, int buildingSize
                 return false;
             }
 
-            // Require the same gravel/slab substrate as Dune structures.
-            // Exact terrain values keep sand, spice, dunes, and mountains out
-            // of every city-only placement path.
-            if(!DuneCity::isCityBuildableTerrain(pTile->getType())
-               || (!bIgnoreUnits && pTile->isBlocked())) {
+            // Zones may spill onto sand as long as one tile anchors on rock or
+            // slab; other city-only structures keep the Dune substrate rule.
+            // Spice, blooms and mountains stay out of every city placement.
+            const uint32_t terrain = pTile->getType();
+            const bool terrainOk = zoneStructure
+                ? DuneCity::isCityZoneTerrain(terrain)
+                : DuneCity::isCityBuildableTerrain(terrain);
+            if(!terrainOk || (!bIgnoreUnits && pTile->isBlocked())) {
                 return false;
+            }
+            if(DuneCity::isCityBuildableTerrain(terrain)) {
+                anchoredTiles++;
             }
 
             if((pHouse == nullptr) || isWithinBuildRange(i, j, pHouse)) {
                 withinBuildRange = true;
             }
         }
+    }
+    if(zoneStructure && anchoredTiles == 0) {
+        return false;
     }
     return withinBuildRange;
 }

--- a/src/Menu/CustomGameMenu.cpp
+++ b/src/Menu/CustomGameMenu.cpp
@@ -37,6 +37,7 @@
 #include <GameInitSettings.h>
 
 #include <globals.h>
+#include <main.h>
 #include <mod/ModManager.h>
 
 #include <algorithm>
@@ -112,6 +113,8 @@ CustomGameMenu::CustomGameMenu(bool multiplayer, bool LANServer)
     leftVBox.addWidget(VSpacer::create(10));
 
     multiplePlayersPerHouseCheckbox.setText(_("Multiple players per house"));
+    multiplePlayersPerHouseCheckbox.setChecked(settings.general.multiplePlayersPerHouse);
+    multiplePlayersPerHouseCheckbox.setOnClick(std::bind(&CustomGameMenu::onMultiplePlayersPerHouseChange, this));
     optionsHBox.addWidget(&multiplePlayersPerHouseCheckbox);
     optionsHBox.addWidget(Spacer::create());
     gameOptionsButton.setText(_("Game Options..."));
@@ -228,6 +231,18 @@ void CustomGameMenu::onChildWindowClose(Window* pChildWindow) {
     GameOptionsWindow* pGameOptionsWindow = dynamic_cast<GameOptionsWindow*>(pChildWindow);
     if(pGameOptionsWindow != nullptr) {
         currentGameOptions = pGameOptionsWindow->getGameOptions();
+        // Choices made here become the new defaults, the same as in Options.
+        saveGameOptionsAsDefaults(currentGameOptions);
+    }
+}
+
+void CustomGameMenu::onMultiplePlayersPerHouseChange() {
+    // Remember the choice across games and restarts.
+    settings.general.multiplePlayersPerHouse = multiplePlayersPerHouseCheckbox.isChecked();
+    INIFile config(getConfigFilepath());
+    config.setBoolValue("General", "Multiple Players Per House", settings.general.multiplePlayersPerHouse);
+    if(!config.saveChangesTo(getConfigFilepath())) {
+        SDL_Log("Warning: could not save 'Multiple Players Per House' to the configuration file");
     }
 }
 

--- a/src/Menu/CustomGamePlayers.cpp
+++ b/src/Menu/CustomGamePlayers.cpp
@@ -233,14 +233,6 @@ CustomGamePlayers::CustomGamePlayers(const GameInitSettings& newGameInitSettings
         extractMapInfo(&inimap);
     }
 
-    // House and color uniqueness is enforced when starting a game. Keep the
-    // lobby consistent with that rule instead of exposing an unusable second
-    // player slot. Loaded multiplayer saves retain their recorded layout.
-    if(gameInitSettings.getGameType() == GameType::CustomGame
-       || gameInitSettings.getGameType() == GameType::CustomMultiplayer) {
-        gameInitSettings.setMultiplePlayersPerHouse(false);
-    }
-
     rightVBox.addWidget(VSpacer::create(10));
     rightVBox.addWidget(&mapPropertiesHBox, 0.01);
     mapPropertiesHBox.addWidget(&mapPropertyNamesVBox, 75);
@@ -1247,7 +1239,6 @@ void CustomGamePlayers::onNext()
     int numTeams = 0;
     bool houseAlreadyUsed[NUM_HOUSES] = {};
     bool colorAlreadyUsed[NUM_HOUSE_COLOR_SLOTS] = {};
-    bool bTwoPlayersInSameHouse = false;
     bool bDuplicateHouse = false;
     bool bDuplicateColor = false;
 
@@ -1262,10 +1253,6 @@ void CustomGamePlayers::onNext()
 
         if(bPlayer1Active || bPlayer2Active) {
             numUsedHouses++;
-
-            if(bPlayer1Active && bPlayer2Active) {
-                bTwoPlayersInSameHouse = true;
-            }
 
             const int selectedHouse = curHouseInfo.houseDropDown.getSelectedEntryIntData();
             if(selectedHouse >= 0 && isCustomGameHouseAvailable(static_cast<HOUSETYPE>(selectedHouse))) {
@@ -1312,8 +1299,6 @@ void CustomGamePlayers::onNext()
     if(numUsedHouses < 2) {
         // No game possible with only 1 house
         openWindow(MsgBox::create(_("At least 2 houses must be controlled\nby a human player or an AI player!")));
-    } else if(bTwoPlayersInSameHouse) {
-        openWindow(MsgBox::create(_("Each player must use a different house/color.")));
     } else if(bDuplicateHouse) {
         openWindow(MsgBox::create(_("The same house cannot be used twice.")));
     } else if(bDuplicateColor) {

--- a/src/Menu/DisplayMenu.cpp
+++ b/src/Menu/DisplayMenu.cpp
@@ -17,8 +17,16 @@ DisplayMenu::DisplayMenu()
     setBackground(pGFXManager->getUIGraphic(UI_MenuBackground));
     resize(getRendererWidth(), getRendererHeight());
     setWindowWidget(&content);
+#ifdef __ANDROID__
+    const bool showAspect = true;
+#else
+    // On desktop the interface takes the shape of the window, so there is no
+    // screen-shape choice to make.
+    const bool showAspect = false;
+#endif
+    const int aspectSection = showAspect ? 76 : 0;
     const int left = (getSize().x - 440) / 2;
-    const int top = (getSize().y - 430) / 2;
+    const int top = (getSize().y - (354 + aspectSection)) / 2;
     title.setText("DISPLAY");
     title.setTextFontSize(22);
     title.setAlignment(Alignment_HCenter);
@@ -33,21 +41,23 @@ DisplayMenu::DisplayMenu()
     }
     selectLayout(selectedLayout);
 
-    aspectTitle.setText("SCREEN SHAPE");
-    aspectTitle.setAlignment(Alignment_HCenter);
-    content.addWidget(&aspectTitle, Point(left, top + 94), Point(440, 24));
-    const char* aspectLabels[] = {"STANDARD 4:3", "WIDESCREEN 16:9"};
-    for(int i = 0; i < 2; ++i) {
-        aspectChoices[i].setText(aspectLabels[i]);
-        aspectChoices[i].setToggleButton(true);
-        aspectChoices[i].setOnClick([this, i] { selectAspect(i == 1); });
-        content.addWidget(&aspectChoices[i], Point(left + i * 224, top + 122), Point(216, 40));
+    if(showAspect) {
+        aspectTitle.setText("SCREEN SHAPE");
+        aspectTitle.setAlignment(Alignment_HCenter);
+        content.addWidget(&aspectTitle, Point(left, top + 94), Point(440, 24));
+        const char* aspectLabels[] = {"STANDARD 4:3", "WIDESCREEN 16:9"};
+        for(int i = 0; i < 2; ++i) {
+            aspectChoices[i].setText(aspectLabels[i]);
+            aspectChoices[i].setToggleButton(true);
+            aspectChoices[i].setOnClick([this, i] { selectAspect(i == 1); });
+            content.addWidget(&aspectChoices[i], Point(left + i * 224, top + 122), Point(216, 40));
+        }
+        selectAspect(selectedWidescreen);
     }
-    selectAspect(selectedWidescreen);
 
     sizeTitle.setText("INTERFACE SIZE");
     sizeTitle.setAlignment(Alignment_HCenter);
-    content.addWidget(&sizeTitle, Point(left, top + 170), Point(440, 24));
+    content.addWidget(&sizeTitle, Point(left, top + 94 + aspectSection), Point(440, 24));
     const char* labels[] = {"LARGE", "MEDIUM", "SMALL", "AUTOMATIC"};
     const int heights[] = {480, 600, 768, 0};
     for(int i = 0; i < 4; ++i) {
@@ -55,9 +65,9 @@ DisplayMenu::DisplayMenu()
         choices[i].setToggleButton(true);
         choices[i].setOnClick([this, height = heights[i]] { select(height); });
         if(i < 3) {
-            content.addWidget(&choices[i], Point(left, top + 198 + i * 44), Point(440, 38));
+            content.addWidget(&choices[i], Point(left, top + 122 + aspectSection + i * 44), Point(440, 38));
         } else {
-            content.addWidget(&choices[i], Point(left, top + 332), Point(440, 38));
+            content.addWidget(&choices[i], Point(left, top + 256 + aspectSection), Point(440, 38));
         }
     }
 #ifdef __ANDROID__
@@ -67,10 +77,10 @@ DisplayMenu::DisplayMenu()
     select(selectedHeight);
     cancelButton.setText("CANCEL");
     cancelButton.setOnClick([this] { quit(); });
-    content.addWidget(&cancelButton, Point(left, top + 378), Point(210, 40));
+    content.addWidget(&cancelButton, Point(left, top + 302 + aspectSection), Point(210, 40));
     applyButton.setText("APPLY");
     applyButton.setOnClick([this] { apply(); });
-    content.addWidget(&applyButton, Point(left + 230, top + 378), Point(210, 40));
+    content.addWidget(&applyButton, Point(left + 230, top + 302 + aspectSection), Point(210, 40));
 }
 
 void DisplayMenu::select(int height) {
@@ -93,8 +103,13 @@ void DisplayMenu::apply() {
     const int selectedWidth = selectedHeight > 0
         ? interfaceWidthForHeight(selectedHeight, selectedWidescreen)
         : settings.video.width;
+#ifdef __ANDROID__
+    const bool widthChanged = selectedHeight > 0 && selectedWidth != settings.video.width;
+#else
+    const bool widthChanged = false; // the width follows the window shape
+#endif
     if(selectedHeight == settings.video.interfaceHeight
-       && (selectedHeight == 0 || selectedWidth == settings.video.width)
+       && !widthChanged
        && selectedLayout == settings.video.startMenuMode) { quit(); return; }
     INIFile config(getConfigFilepath());
     config.setIntValue("Video", "Interface Height", selectedHeight);

--- a/src/Menu/HouseChoiceMenu.cpp
+++ b/src/Menu/HouseChoiceMenu.cpp
@@ -173,6 +173,8 @@ void HouseChoiceMenu::onChildWindowClose(Window* pChildWindow) {
     GameOptionsWindow* pGameOptionsWindow = dynamic_cast<GameOptionsWindow*>(pChildWindow);
     if(pGameOptionsWindow != nullptr) {
         s_currentGameOptions = pGameOptionsWindow->getGameOptions();
+        // Choices made here become the new defaults, the same as in Options.
+        saveGameOptionsAsDefaults(s_currentGameOptions);
     }
 }
 

--- a/src/Menu/OptionsMenu.cpp
+++ b/src/Menu/OptionsMenu.cpp
@@ -29,6 +29,7 @@
 #include <FileClasses/GFXManager.h>
 #include <FileClasses/TextManager.h>
 #include <FileClasses/INIFile.h>
+#include <mod/ModManager.h>
 #include <FileClasses/music/MusicPlayer.h>
 
 #include <SoundPlayer.h>
@@ -499,7 +500,7 @@ void OptionsMenu::onOptionsOK() {
     settings.audio.playMusic = playMusicCheckbox.isChecked();
     settings.audio.playCreditsSFX = playCreditsSFXCheckbox.isChecked();
 
-    settings.gameOptions = currentGameOptions;
+    saveGameOptionsAsDefaults(currentGameOptions);
 
     settings.network.serverPort = serverport;
     settings.network.metaServer = metaserver;
@@ -528,10 +529,23 @@ void OptionsMenu::onGameOptions() {
 void OptionsMenu::onRestoreDefaults() {
     // Restore config files
     if (restoreDefaultConfigs()) {
+        // Forget the player's game option choices for this mod too, so the
+        // mod's own defaults come back.
+        const std::string section = userGameOptionsSection();
+        if(!section.empty()) {
+            INIFile config(getConfigFilepath());
+            if(config.hasSection(section)) {
+                config.removeSection(section);
+                config.saveChangesTo(getConfigFilepath());
+            }
+        }
+        effectiveGameOptions = ModManager::instance().loadEffectiveGameOptions(settings.gameOptions);
+        currentGameOptions = effectiveGameOptions;
+
         std::string successMessage = 
             "Config files restored successfully!\n\n"
-            "ObjectData.ini and QuantBot Config.ini have been\n"
-            "reset to default values.\n\n"
+            "ObjectData.ini, QuantBot Config.ini and the game\n"
+            "option defaults have been reset.\n\n"
             "IMPORTANT: Changes will take effect on next game start.\n"
             "Please restart the game.";
         MsgBox* pMsgBox = MsgBox::create(successMessage);
@@ -551,6 +565,7 @@ void OptionsMenu::saveConfiguration2File() {
 
     myINIFile.setBoolValue("General","Play Intro",settings.general.playIntro);
     myINIFile.setBoolValue("General","Show Tutorial Hints",settings.general.showTutorialHints);
+    myINIFile.setBoolValue("General","Multiple Players Per House",settings.general.multiplePlayersPerHouse);
 
     myINIFile.setIntValue("Video","Physical Width",settings.video.physicalWidth);
     myINIFile.setIntValue("Video","Physical Height",settings.video.physicalHeight);
@@ -646,10 +661,19 @@ void OptionsMenu::determineAvailableScreenResolutions() {
         return;
     }
     
+    // Fullscreen is always desktop-sized and a window cannot be larger than the
+    // desktop, so modes beyond it (e.g. the native pixel resolution of a Retina
+    // panel, which SDL lists next to the scaled modes) can never be used.
+    SDL_Rect displayBounds = {0, 0, 0, 0};
+    const bool haveDisplayBounds = (SDL_GetDisplayBounds(displayIndex, &displayBounds) == 0
+                                    && displayBounds.w > 0 && displayBounds.h > 0);
+
     for(int i = numDisplayModes-1; i >=0; i--) {
         if(SDL_GetDisplayMode(displayIndex, i, &displayMode) == 0) {
             Coord screenRes(displayMode.w, displayMode.h);
-            if(screenRes.x >= SCREEN_MIN_WIDTH && screenRes.y >= SCREEN_MIN_HEIGHT) {
+            const bool fitsDisplay = !haveDisplayBounds
+                                     || (screenRes.x <= displayBounds.w && screenRes.y <= displayBounds.h);
+            if(fitsDisplay && screenRes.x >= SCREEN_MIN_WIDTH && screenRes.y >= SCREEN_MIN_HEIGHT) {
                 if(std::find(availScreenRes.begin(), availScreenRes.end(), screenRes) == availScreenRes.end()) {
                     // not yet in the list (might happen if e.g. multiple refresh rates are reported)
                     availScreenRes.push_back(screenRes);

--- a/src/Menu/SinglePlayerSkirmishMenu.cpp
+++ b/src/Menu/SinglePlayerSkirmishMenu.cpp
@@ -247,6 +247,8 @@ void SinglePlayerSkirmishMenu::onChildWindowClose(Window* pChildWindow) {
     GameOptionsWindow* pGameOptionsWindow = dynamic_cast<GameOptionsWindow*>(pChildWindow);
     if(pGameOptionsWindow != nullptr) {
         currentGameOptions = pGameOptionsWindow->getGameOptions();
+        // Choices made here become the new defaults, the same as in Options.
+        saveGameOptionsAsDefaults(currentGameOptions);
     }
 }
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -17,6 +17,8 @@
 
 #include <globals.h>
 #include <mod/ModManager.h>
+#include <main.h>
+#include <FileClasses/INIFile.h>
 
 #include <SoundPlayer.h>
 #include <FileClasses/music/MusicPlayer.h>
@@ -118,6 +120,80 @@ const std::array<SDL_Color, 8> darkGreyRamp{{
     {42, 42, 42, 255}, {34, 34, 34, 255}, {27, 27, 27, 255}, {20, 20, 20, 255}
 }};
 
+}
+
+std::string userGameOptionsSection() {
+    const ModManager& mods = ModManager::instance();
+    if(!mods.isInitialized() || mods.getActiveModName() == "vanilla") {
+        return std::string();
+    }
+    return "Game Options " + mods.getActiveModName();
+}
+
+void writeGameOptionsToConfig(INIFile& config, const std::string& section, const SettingsClass::GameOptionsClass& options) {
+    config.setIntValue(section, "Game Speed", options.gameSpeed);
+    config.setBoolValue(section, "Concrete Required", options.concreteRequired);
+    config.setBoolValue(section, "Structures Degrade On Concrete", options.structuresDegradeOnConcrete);
+    config.setBoolValue(section, "Fog of War", options.fogOfWar);
+    config.setBoolValue(section, "Start with Explored Map", options.startWithExploredMap);
+    config.setBoolValue(section, "Instant Build", options.instantBuild);
+    config.setBoolValue(section, "Only One Palace", options.onlyOnePalace);
+    config.setBoolValue(section, "Rocket-Turrets Need Power", options.rocketTurretsNeedPower);
+    config.setBoolValue(section, "Sandworms Respawn", options.sandwormsRespawn);
+    config.setBoolValue(section, "Killed Sandworms Drop Spice", options.killedSandwormsDropSpice);
+    config.setBoolValue(section, "Manual Carryall Drops", options.manualCarryallDrops);
+    config.setIntValue(section, "Maximum Number of Units Override", options.maximumNumberOfUnitsOverride);
+    config.setIntValue(section, "Maximum Number of Harvesters Override", options.maximumNumberOfHarvestersOverride);
+    config.setBoolValue(section, "Immortal Human Player", options.immortalHumanPlayer);
+    config.setBoolValue(section, "City Effects", options.cityEffects);
+}
+
+void applyGameOptionsFromConfig(const INIFile& config, const std::string& section, SettingsClass::GameOptionsClass& options) {
+    if(section.empty() || !config.hasSection(section)) {
+        return;
+    }
+    auto readBool = [&](const char* key, bool& field) {
+        if(config.hasKey(section, key)) field = config.getBoolValue(section, key, field);
+    };
+    auto readInt = [&](const char* key, int& field) {
+        if(config.hasKey(section, key)) field = config.getIntValue(section, key, field);
+    };
+    readInt("Game Speed", options.gameSpeed);
+    readBool("Concrete Required", options.concreteRequired);
+    readBool("Structures Degrade On Concrete", options.structuresDegradeOnConcrete);
+    readBool("Fog of War", options.fogOfWar);
+    readBool("Start with Explored Map", options.startWithExploredMap);
+    readBool("Instant Build", options.instantBuild);
+    readBool("Only One Palace", options.onlyOnePalace);
+    readBool("Rocket-Turrets Need Power", options.rocketTurretsNeedPower);
+    readBool("Sandworms Respawn", options.sandwormsRespawn);
+    readBool("Killed Sandworms Drop Spice", options.killedSandwormsDropSpice);
+    readBool("Manual Carryall Drops", options.manualCarryallDrops);
+    readInt("Maximum Number of Units Override", options.maximumNumberOfUnitsOverride);
+    readInt("Maximum Number of Harvesters Override", options.maximumNumberOfHarvestersOverride);
+    readBool("Immortal Human Player", options.immortalHumanPlayer);
+    readBool("City Effects", options.cityEffects);
+}
+
+void saveGameOptionsAsDefaults(const SettingsClass::GameOptionsClass& options) {
+    settings.gameOptions = options;
+
+    INIFile config(getConfigFilepath());
+    writeGameOptionsToConfig(config, "Game Options", options);
+    const std::string section = userGameOptionsSection();
+    if(!section.empty()) {
+        // The mod's own GameOptions.ini stays untouched: it is hashed for
+        // multiplayer config checks. The player's choices live here instead
+        // and are layered over the mod's defaults.
+        writeGameOptionsToConfig(config, section, options);
+    }
+    if(!config.saveChangesTo(getConfigFilepath())) {
+        SDL_Log("Warning: could not save the game option defaults to the configuration file");
+    }
+
+    effectiveGameOptions = ModManager::instance().loadEffectiveGameOptions(settings.gameOptions);
+    SDL_Log("Game options saved as defaults%s%s", section.empty() ? "" : " for mod ",
+            section.empty() ? "" : ModManager::instance().getActiveModName().c_str());
 }
 
 void loadCustomPalette() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@
 
 #include <main.h>
 
+#include <algorithm>
+#include <cmath>
 #include <globals.h>
 
 #include <config.h>
@@ -131,6 +133,29 @@ int getLogicalToPhysicalResolutionFactor(int physicalWidth, int physicalHeight) 
     }
 }
 
+// Keeps a windowed size inside the usable desktop area (the display minus menu
+// bar, dock or task bar) so the whole window is visible. Units are the screen
+// coordinates SDL_CreateWindow takes.
+static void clampWindowedSizeToDisplay(int displayIndex, int& width, int& height) {
+    SDL_Rect usableBounds = {0, 0, 0, 0};
+    if(SDL_GetDisplayUsableBounds(displayIndex, &usableBounds) != 0 || usableBounds.w <= 0 || usableBounds.h <= 0) {
+        return;
+    }
+    width = std::min(width, usableBounds.w);
+    height = std::min(height, usableBounds.h);
+}
+
+// Logical width that gives a `height`-tall interface the same shape as a
+// presentedWidth x presentedHeight surface, so it fills the window without
+// black bars. Even, and never below the minimum width.
+static int interfaceWidthForShape(int height, int presentedWidth, int presentedHeight) {
+    if(presentedWidth <= 0 || presentedHeight <= 0) {
+        return interfaceWidthForHeight(height, false);
+    }
+    const int width = static_cast<int>(std::lround(static_cast<double>(height) * presentedWidth / presentedHeight));
+    return std::max(SCREEN_MIN_WIDTH, width & ~1);
+}
+
 void setVideoMode(int displayIndex)
 {
     int videoFlags = 0;
@@ -142,9 +167,14 @@ void setVideoMode(int displayIndex)
         false
 #endif
     );
-    const int requestedInterfaceWidth = requestedInterfaceHeight > 0
+    [[maybe_unused]] const int requestedInterfaceWidth = requestedInterfaceHeight > 0
         ? validatedInterfaceWidth(settings.video.width, requestedInterfaceHeight)
         : settings.video.width;
+
+    // Size of what ends up on screen, in screen coordinates: the window, or
+    // the desktop for a fullscreen-desktop window.
+    int presentedWidth = 0;
+    int presentedHeight = 0;
 
 #ifdef __EMSCRIPTEN__
     // Keep SDL's logical surface independent from the browser viewport. CSS
@@ -156,45 +186,56 @@ void setVideoMode(int displayIndex)
     settings.video.physicalHeight = 480;
     settings.video.width = 640;
     settings.video.height = 480;
+    presentedWidth = 640;
+    presentedHeight = 480;
 #else
     if(settings.video.fullscreen) {
         videoFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
 #ifdef __ANDROID__
     videoFlags |= SDL_WINDOW_RESIZABLE;
+#else
+    // Render at the display's native pixel density. On a Retina Mac a
+    // 1440x900 window then has a 2880x1800 pixel surface, so a 960x600
+    // interface is drawn at an exact 3x instead of an uneven 1.5x. Window
+    // sizes stay in screen coordinates and SDL converts mouse events to the
+    // logical size, so nothing else changes.
+    videoFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
 #endif
 
-    SDL_DisplayMode targetDisplayMode = { 0, settings.video.physicalWidth, settings.video.physicalHeight, 0, nullptr};
-    SDL_DisplayMode closestDisplayMode;
+    // The game never switches the display mode: fullscreen means
+    // SDL_WINDOW_FULLSCREEN_DESKTOP, which covers the desktop at whatever
+    // resolution it currently has, and a window may have any size. So the
+    // requested physical size is used as-is; the only adjustment is keeping a
+    // window inside the usable desktop area. Older versions snapped the request
+    // to SDL's "closest display mode" here, which on Retina Macs turned
+    // 1280x800 into 1920x1200 (SDL only considers low-density modes as
+    // candidates), so changing the windowed resolution never took effect.
+    settings.video.physicalWidth = std::max(settings.video.physicalWidth, SCREEN_MIN_WIDTH);
+    settings.video.physicalHeight = std::max(settings.video.physicalHeight, SCREEN_MIN_HEIGHT);
+    if(!settings.video.fullscreen) {
+        clampWindowedSizeToDisplay(displayIndex, settings.video.physicalWidth, settings.video.physicalHeight);
+    }
 
-    if(SDL_GetClosestDisplayMode(displayIndex, &targetDisplayMode, &closestDisplayMode) == nullptr) {
-        SDL_Log("Warning: Falling back to a display resolution of 640x480!");
-        settings.video.physicalWidth = 640;
-        settings.video.physicalHeight = 480;
-        int factor = getLogicalToPhysicalResolutionFactor(settings.video.physicalWidth, settings.video.physicalHeight);
-        // Prevent division by zero and ensure minimum dimensions
+    {
+        // Derive the logical (interface) size from what actually ends up on
+        // screen: for a fullscreen-desktop window that is the desktop, not the
+        // saved windowed size.
+        presentedWidth = settings.video.physicalWidth;
+        presentedHeight = settings.video.physicalHeight;
+        SDL_DisplayMode desktopDisplayMode;
+        if(settings.video.fullscreen
+           && SDL_GetDesktopDisplayMode(displayIndex, &desktopDisplayMode) == 0
+           && desktopDisplayMode.w > 0 && desktopDisplayMode.h > 0) {
+            presentedWidth = desktopDisplayMode.w;
+            presentedHeight = desktopDisplayMode.h;
+        }
+        int factor = getLogicalToPhysicalResolutionFactor(presentedWidth, presentedHeight);
         if(factor <= 0) {
             factor = 1;
         }
-        settings.video.width = settings.video.physicalWidth / factor;
-        settings.video.height = settings.video.physicalHeight / factor;
-        // Ensure minimum dimensions
-        if(settings.video.width < 640) settings.video.width = 640;
-        if(settings.video.height < 480) settings.video.height = 480;
-    } else {
-        settings.video.physicalWidth = closestDisplayMode.w;
-        settings.video.physicalHeight = closestDisplayMode.h;
-        int factor = getLogicalToPhysicalResolutionFactor(settings.video.physicalWidth, settings.video.physicalHeight);
-        // Prevent division by zero and ensure minimum dimensions
-        if(factor <= 0) {
-            factor = 1;
-        }
-        settings.video.width = settings.video.physicalWidth / factor;
-        settings.video.height = settings.video.physicalHeight / factor;
-        
-        // Ensure minimum dimensions
-        if(settings.video.width < 640) settings.video.width = 640;
-        if(settings.video.height < 480) settings.video.height = 480;
+        settings.video.width = std::max(presentedWidth / factor, SCREEN_MIN_WIDTH);
+        settings.video.height = std::max(presentedHeight / factor, SCREEN_MIN_HEIGHT);
     }
 
 #ifdef __ANDROID__
@@ -233,6 +274,20 @@ void setVideoMode(int displayIndex)
         exit(EXIT_FAILURE);
     }
 
+    {
+        int windowWidth = 0;
+        int windowHeight = 0;
+        int pixelWidth = 0;
+        int pixelHeight = 0;
+        SDL_GetWindowSize(window, &windowWidth, &windowHeight);
+        SDL_GetRendererOutputSize(renderer, &pixelWidth, &pixelHeight);
+        SDL_Log("Window: %dx%d requested, %dx%d created (%s), %dx%d pixels",
+                settings.video.physicalWidth, settings.video.physicalHeight,
+                windowWidth, windowHeight,
+                settings.video.fullscreen ? "fullscreen desktop" : "windowed",
+                pixelWidth, pixelHeight);
+    }
+
 #ifdef __ANDROID__
     // The Android display mode can describe the complete panel while the SDL
     // surface is a foldable, split-screen, or desktop-mode window. The renderer
@@ -264,7 +319,13 @@ void setVideoMode(int displayIndex)
 #endif
     if(settings.video.interfaceHeight > 0) {
         settings.video.height = settings.video.interfaceHeight;
+#ifdef __ANDROID__
         settings.video.width = validatedInterfaceWidth(requestedInterfaceWidth, settings.video.height);
+#else
+        // Only the height is a preset; the width follows the shape of the
+        // window (or desktop) so the interface fills it without black bars.
+        settings.video.width = interfaceWidthForShape(settings.video.height, presentedWidth, presentedHeight);
+#endif
     }
     SDL_Log("Display: %dx%d physical, %dx%d logical, interface preset=%d",
             settings.video.physicalWidth, settings.video.physicalHeight,
@@ -600,6 +661,7 @@ void createDefaultConfigFile(const std::string& configfilepath, const std::strin
                                 "Language = %s               # en = English, fr = French, de = German\n"
                                 "Scroll Speed = 50           # Amount to scroll the map when the cursor is near the screen border\n"
                                 "Show Tutorial Hints = true  # Show tutorial hints during the game\n"
+                                "Multiple Players Per House = false  # Custom game: allow two players per house\n"
                                 "\n"
                                 "[Video]\n"
                                 "# Minimum resolution is 640x480\n"
@@ -629,6 +691,7 @@ void createDefaultConfigFile(const std::string& configfilepath, const std::strin
                                 "Music Volume = 64           # Volume between 0 and 128\n"
                                 "Play SFX = true\n"
                                 "SFX Volume = 64             # Volume between 0 and 128\n"
+                                "Play Credits SFX = false    # Play sound when credits change (harvester deliveries, spending credits)\n"
                                 "\n"
                                 "[Network]\n"
                                 "ServerPort = %d\n"
@@ -991,6 +1054,7 @@ int main(int argc, char *argv[]) {
             settings.general.language = myINIFile.getStringValue("General","Language","en");
             settings.general.scrollSpeed = myINIFile.getIntValue("General","Scroll Speed",50);
             settings.general.showTutorialHints = myINIFile.getBoolValue("General","Show Tutorial Hints",true);
+            settings.general.multiplePlayersPerHouse = myINIFile.getBoolValue("General","Multiple Players Per House",false);
             settings.video.width = myINIFile.getIntValue("Video","Width",640);
             settings.video.height = myINIFile.getIntValue("Video","Height",480);
             settings.video.interfaceHeight = validatedInterfaceHeight(
@@ -1019,7 +1083,7 @@ int main(int argc, char *argv[]) {
             settings.audio.musicVolume = myINIFile.getIntValue("Audio","Music Volume", 64);
             settings.audio.playSFX = myINIFile.getBoolValue("Audio","Play SFX", true);
             settings.audio.sfxVolume = myINIFile.getIntValue("Audio","SFX Volume", 64);
-            settings.audio.playCreditsSFX = myINIFile.getBoolValue("Audio","Play Credits SFX", true);
+            settings.audio.playCreditsSFX = myINIFile.getBoolValue("Audio","Play Credits SFX", false);
 
             settings.network.serverPort = myINIFile.getIntValue("Network","ServerPort",DEFAULT_PORT);
             settings.network.metaServer = myINIFile.getStringValue("Network","MetaServer",DEFAULT_METASERVER);
@@ -1100,7 +1164,6 @@ int main(int argc, char *argv[]) {
                 SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION, "1");
                 SDL_SetHint(SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES, "0");
                 SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "0");
-                SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, "1");
                 SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
                 // VSync disabled by default - controlled via renderer flags in setVideoMode()
                 SDL_SetHint(SDL_HINT_RENDER_VSYNC, "0");

--- a/src/mod/ModManager.cpp
+++ b/src/mod/ModManager.cpp
@@ -29,6 +29,8 @@
 #include <misc/exceptions.h>
 #include <Definitions.h>
 #include <globals.h>
+#include <main.h>
+#include <FileClasses/INIFile.h>
 #include <config.h>
 
 #include <SDL.h>
@@ -642,9 +644,20 @@ SettingsClass::GameOptionsClass ModManager::loadEffectiveGameOptions(
         return result;
     }
     
+    // The player's own choices for this mod (saved from the Options screen or
+    // a game lobby) sit on top of whatever the mod file says.
+    auto applyPlayerChoices = [&]() {
+        try {
+            applyGameOptionsFromConfig(INIFile(getConfigFilepath()), userGameOptionsSection(), result);
+        } catch (const std::exception& e) {
+            SDL_Log("ModManager: Warning - could not read the player's game option overrides: %s", e.what());
+        }
+    };
+
     // Try to load mod's GameOptions.ini
     std::string gameOptionsPath = getActiveGameOptionsPath();
     if (!existsFile(gameOptionsPath)) {
+        applyPlayerChoices();
         return result;
     }
     
@@ -703,7 +716,8 @@ SettingsClass::GameOptionsClass ModManager::loadEffectiveGameOptions(
     } catch (const std::exception& e) {
         SDL_Log("ModManager: Warning - failed to load game options from mod: %s", e.what());
     }
-    
+
+    applyPlayerChoices();
     return result;
 }
 

--- a/src/players/QuantBot.cpp
+++ b/src/players/QuantBot.cpp
@@ -29,6 +29,7 @@
 #include <structures/BuilderBase.h>
 #include <structures/StarPort.h>
 #include <structures/ConstructionYard.h>
+#include <players/QuantBotBuildPolicy.h>
 #include <structures/RepairYard.h>
 #include <structures/Palace.h>
 #include <units/UnitBase.h>
@@ -956,6 +957,76 @@ Coord QuantBot::findMcvPlaceLocation(const MCV* pMCV) {
 	return bestLocation;
 }
 
+namespace {
+
+// A structure on this tile that is one of our city zones, or nullptr.
+const StructureBase* ownZoneAt(const Map& map, int houseID, int x, int y) {
+	if (!map.tileExists(x, y)) return nullptr;
+	const ObjectBase* pObject = map.getTile(x, y)->getNonInfantryGroundObject();
+	if (pObject == nullptr || !pObject->isAStructure()) return nullptr;
+	const auto* pStructure = static_cast<const StructureBase*>(pObject);
+	if (!DuneCity::isCityZoneStructure(pStructure->getItemID())) return nullptr;
+	if (pStructure->getOwner() == nullptr || pStructure->getOwner()->getHouseID() != houseID) return nullptr;
+	return pStructure;
+}
+
+// True when the tile could carry a road or already does, ignoring tiles that
+// the candidate footprint (x, y, w, h) is about to cover.
+bool tileKeepsFrontage(const Map& map, int tx, int ty, int x, int y, int w, int h) {
+	if (!map.tileExists(tx, ty)) return false;
+	if (tx >= x && tx < x + w && ty >= y && ty < y + h) return false;
+	const Tile* t = map.getTile(tx, ty);
+	if (t->isRoad()) return true;
+	return !t->hasAStructure() && !t->hasCityZone() && !t->isMountain()
+		&& !t->hasAGroundObject() && DuneCity::isCityZoneTerrain(t->getType());
+}
+
+// Would a lot at (x, y, w, h) take away the last open side of a neighbouring
+// zone? Every lot must keep a side where a road can run.
+bool wouldLandlockNeighbouringZone(const Map& map, int houseID, int x, int y, int w, int h) {
+	std::set<Uint32> checked;
+	auto sealsNeighbour = [&](int nx, int ny) {
+		const StructureBase* pZone = ownZoneAt(map, houseID, nx, ny);
+		if (pZone == nullptr || !checked.insert(pZone->getObjectID()).second) return false;
+		const int zx = pZone->getX(), zy = pZone->getY();
+		const int zw = pZone->getStructureSizeX(), zh = pZone->getStructureSizeY();
+		for (int i = zx; i < zx + zw; i++) {
+			if (tileKeepsFrontage(map, i, zy - 1, x, y, w, h)) return false;
+			if (tileKeepsFrontage(map, i, zy + zh, x, y, w, h)) return false;
+		}
+		for (int j = zy; j < zy + zh; j++) {
+			if (tileKeepsFrontage(map, zx - 1, j, x, y, w, h)) return false;
+			if (tileKeepsFrontage(map, zx + zw, j, x, y, w, h)) return false;
+		}
+		return true;
+	};
+	for (int i = x; i < x + w; i++) {
+		if (sealsNeighbour(i, y - 1) || sealsNeighbour(i, y + h)) return true;
+	}
+	for (int j = y; j < y + h; j++) {
+		if (sealsNeighbour(x - 1, j) || sealsNeighbour(x + w, j)) return true;
+	}
+	return false;
+}
+
+// Is there one of our zones directly beside this lot, or one road tile away,
+// sharing its row or column? That is the "next to each other or one away"
+// pattern that keeps a road path along every row of lots.
+bool alignedWithNeighbouringZone(const Map& map, int houseID, int x, int y, int w, int h) {
+	const int offsets[4][2] = { { w, 0 }, { w + 1, 0 }, { 0, h }, { 0, h + 1 } };
+	for (const auto& offset : offsets) {
+		for (int sign = -1; sign <= 1; sign += 2) {
+			const int nx = x + sign * offset[0];
+			const int ny = y + sign * offset[1];
+			const StructureBase* pZone = ownZoneAt(map, houseID, nx, ny);
+			if (pZone != nullptr && pZone->getX() == nx && pZone->getY() == ny) return true;
+		}
+	}
+	return false;
+}
+
+} // namespace
+
 Coord QuantBot::findPlaceLocation(Uint32 itemID) {
 	// Check per-build-cycle cache first
 	auto cacheIt = placementCache.find(itemID);
@@ -978,6 +1049,13 @@ Coord QuantBot::findPlaceLocation(Uint32 itemID) {
 		|| itemID == Structure_WOR
 		|| itemID == Structure_Barracks
 		|| itemID == Structure_StarPort);
+
+	// City zones follow road-frontage rules instead of the compact-base
+	// scoring: they sit next to each other or one road tile apart, and never
+	// pack into blocks that landlock the inner lots.
+	const bool cityZonePlacement = currentGame && currentGame->isCitySimEnabled()
+		&& DuneCity::isCityZoneStructure(itemID);
+	const int houseID = getHouse()->getHouseID();
 
 	// Bound search to radius around base center instead of scanning entire map
 	int searchRadius = 50;
@@ -1039,7 +1117,7 @@ Coord QuantBot::findPlaceLocation(Uint32 itemID) {
 						// Favor being near our buildings, avoid enemy buildings
 						if (getMap().getTile(i, j)->getOwner() == getHouse()->getHouseID()) {
 							adjacentFriendlyStructureTiles++;
-							locationScore += 10;  // Base linear bonus
+							locationScore += cityZonePlacement ? 0 : 10;  // compact bases only; lots keep frontage instead
 							
 							// Track which side this building is on and which building it is
 							const ObjectBase* pObject = getMap().getTile(i, j)->getObject();
@@ -1204,7 +1282,9 @@ Coord QuantBot::findPlaceLocation(Uint32 itemID) {
 			int gridOffsetX = ((placeLocationX - baseCenter.x) % 3 + 3) % 3;
 			int gridOffsetY = ((placeLocationY - baseCenter.y) % 3 + 3) % 3;
 			if (gridOffsetX == 0 && gridOffsetY == 0) {
-				locationScore += 80;  // strong grid alignment bonus
+				locationScore += 40;  // grid alignment bonus
+			} else if (cityZonePlacement && alignedWithNeighbouringZone(getMap(), houseID, placeLocationX, placeLocationY, newSizeX, newSizeY)) {
+				locationScore += 50;  // continues a row of lots: touching or one road tile apart
 			} else {
 				locationScore -= 40;  // off-grid penalty
 			}
@@ -1241,6 +1321,9 @@ Coord QuantBot::findPlaceLocation(Uint32 itemID) {
 			if (sidesWithRoad == 0 && sidesWithOpen == 0) {
 				continue;  // landlocked — skip
 			}
+			if (cityZonePlacement && wouldLandlockNeighbouringZone(getMap(), houseID, placeLocationX, placeLocationY, newSizeX, newSizeY)) {
+				continue;  // would take a neighbour's last road frontage
+			}
 			locationScore += sidesWithRoad * 25;
 			locationScore += sidesWithOpen * 5;
 			locationScore -= sidesTouchingStructure * 30;
@@ -1254,6 +1337,18 @@ Coord QuantBot::findPlaceLocation(Uint32 itemID) {
 			bool isIndustrial  = (itemID == Structure_ZoneIndustrial);
 
 			if (isResidential || isCommercial || isIndustrial) {
+				// Favour lots that use sand so rock stays free for Dune
+				// structures. The placement check already guarantees at
+				// least one rock tile under the lot.
+				for (int px = placeLocationX; px < placeLocationEndX; px++) {
+					for (int py = placeLocationY; py < placeLocationEndY; py++) {
+						if (getMap().tileExists(px, py)) {
+							const Tile* t = getMap().getTile(px, py);
+							if (t->isSand() || t->isDunes()) locationScore += 6;
+						}
+					}
+				}
+
 				int closestIndDist = 100;
 				int nearbyRes = 0, nearbyCom = 0, nearbyInd = 0;
 
@@ -1771,7 +1866,9 @@ void QuantBot::build(int militaryValue) {
 			if (pStructure->isABuilder()) {
 				const BuilderBase* pBuilder = static_cast<const BuilderBase*>(pStructure);
 				if (pBuilder->getProductionQueueSize() > 0) {
-					itemCount[pBuilder->getCurrentProducedItem()]++;
+					for (const auto& queued : pBuilder->getBuildList()) {
+						itemCount[queued.itemID] += queued.num;
+					}
 					if (pBuilder->getItemID() == Structure_HeavyFactory) {
 						activeHeavyFactoryCount++;
 					}
@@ -1841,9 +1938,10 @@ void QuantBot::build(int militaryValue) {
 
 	const bool customStrategicPlanning = gameMode == GameMode::Custom && !supportMode;
 	const bool stablePower = getHouse()->getProducedPower() >= getHouse()->getPowerRequirement();
-	const bool palaceAllowedNow = citySimEnabled
-		? itemCount[Structure_Palace] < 1 + ownTotalPop / 25
-		: itemCount[Structure_Palace] == 0;
+	const int palaceTarget = QuantBotBuildPolicy::palaceTarget(
+		getGameInitSettings().getGameOptions().onlyOnePalace, citySimEnabled,
+		ownTotalPop * DuneCity::CitySimulation::kPopDisplayMultiplier);
+	const bool palaceAllowedNow = itemCount[Structure_Palace] < palaceTarget;
 	const bool ixEligible = customStrategicPlanning
 		&& itemCount[Structure_IX] == 0
 		&& itemCount[Structure_HeavyFactory] > 0
@@ -1896,6 +1994,24 @@ void QuantBot::build(int militaryValue) {
 	} else if (stablePower && palaceOverdue) {
 		strategicReserveItem = Structure_Palace;
 	}
+	// Reserve only the cost of a feasible order. An unplaceable structure must
+	// not freeze production indefinitely, and excess funds remain spendable.
+	if (strategicReserveItem != NONE_ID && !findPlaceLocation(strategicReserveItem).isValid()) {
+		strategicReserveItem = NONE_ID;
+	}
+	int strategicReserveCost = strategicReserveItem == NONE_ID ? 0
+		: data[strategicReserveItem][houseID].price;
+
+	auto chooseCityZone = [&](const BuilderBase* builder, bool bootstrap) {
+		const auto ranked = QuantBotBuildPolicy::rankZones(
+			itemCount[Structure_ZoneResidential], itemCount[Structure_ZoneCommercial],
+			itemCount[Structure_ZoneIndustrial], ownResValve, ownComValve, ownIndValve, bootstrap);
+		for (Uint32 candidate : ranked) {
+			if (candidate != NONE_ID && builder->isAvailableToBuild(candidate)
+				&& findPlaceLocation(candidate).isValid()) return candidate;
+		}
+		return static_cast<Uint32>(NONE_ID);
+	};
 
 	bool emitStatsLog = false;
 
@@ -2215,16 +2331,24 @@ void QuantBot::build(int militaryValue) {
 						std::string itemName = getItemNameByID(itemID);
 						logDebug("Queuing %s (ID:%d)", itemName.c_str(), itemID);
 					}
+					const int before = pBuilder->getProductionQueueSize();
 					doProduceItem(pBuilder, itemID);
+					const bool accepted = pBuilder->getProductionQueueSize() > before;
+					if (!accepted && emitStatsLog) {
+						logDebug("PRODUCTION: builder=%u rejected item=%u credits=%d", pBuilder->getObjectID(), itemID, money);
+					}
+					return accepted;
 				};
 
-				// Preserve the bank regardless of builder iteration order once strategic
-				// infrastructure has aged into priority. The Construction Yard remains
-				// active so it can spend the reserved credits on the intended structure.
-				if (strategicReserveItem != NONE_ID
-					&& pStructure->getItemID() != Structure_ConstructionYard) {
-					continue;
-				}
+				// Restore the reserved portion after this builder's decisions, keeping
+				// all existing local spending deductions for subsequent builders.
+				struct RestoreReservedCredits {
+					int& money;
+					int reserved;
+					~RestoreReservedCredits() { money += reserved; }
+				} reserve{money, pStructure->getItemID() == Structure_ConstructionYard
+					? 0 : money - QuantBotBuildPolicy::spendableCredits(money, strategicReserveCost)};
+				money -= reserve.reserved;
 				
 				if (!pBuilder->isUpgrading() && pBuilder->getProductionQueueSize() < 1
 					&& money > 1500) {
@@ -2364,11 +2488,12 @@ void QuantBot::build(int militaryValue) {
 				case Structure_HeavyFactory: {
 					// Log HF status when idle with money (Custom mode diagnostics)
 					if (gameMode == GameMode::Custom && emitStatsLog) {
-						logDebug("HF: upgrading=%d queue=%d buildList=%d upgLv=%d/%d unitLimit=%d money=%d",
-							pBuilder->isUpgrading(), pBuilder->getProductionQueueSize(),
+						logDebug("HF=%u: upgrading=%d queue=%d buildList=%d upgLv=%d/%d unitLimit=%d spendable=%d hold=%d military=%d/%d reserve=%d",
+							pBuilder->getObjectID(), pBuilder->isUpgrading(), pBuilder->getProductionQueueSize(),
 							pBuilder->getBuildListSize(),
 							pBuilder->getCurrentUpgradeLevel(), pBuilder->getMaxUpgradeLevel(),
-							getHouse()->isGroundUnitLimitReached(), money);
+							getHouse()->isGroundUnitLimitReached(), money, pBuilder->isOnHold(),
+							militaryValue, militaryValueLimit, strategicReserveCost);
 					}
 					// only if the factory isn't busy
 					if ((pBuilder->isUpgrading() == false) && (pBuilder->getProductionQueueSize() < 1) && (pBuilder->getBuildListSize() > 0)) {
@@ -2492,7 +2617,7 @@ void QuantBot::build(int militaryValue) {
 							else if (pBuilder->isAvailableToBuild(Unit_SiegeTank) && (militaryValue * siegePercent > siegeValue)) {
 								produceItemWithLogging(Unit_SiegeTank);
 								itemCount[Unit_SiegeTank]++;
-								money -= data[Unit_Tank][houseID].price;
+								money -= data[Unit_SiegeTank][houseID].price;
 								militaryValue += data[Unit_SiegeTank][houseID].price;
 							}
 							else if (pBuilder->isAvailableToBuild(Unit_Tank)) {
@@ -2596,19 +2721,16 @@ void QuantBot::build(int militaryValue) {
 
 				const ConstructionYard* pConstYard = static_cast<const ConstructionYard*>(pBuilder);
 
-				// Only log production status when something changes (not every cycle)
-				static int lastQueueSize = -1;
-				static bool lastUpgrading = false;
-				static int lastBuildListSize = -1;
-				
-				if(pBuilder->getProductionQueueSize() != lastQueueSize || 
-				   pBuilder->isUpgrading() != lastUpgrading || 
-				   pBuilder->getBuildListSize() != lastBuildListSize) {
-					logDebug("PRODUCTION: CY Status - Upgrading:%d Queue:%d Credits:%d BuildList:%d", 
-						pBuilder->isUpgrading(), pBuilder->getProductionQueueSize(), money, pBuilder->getBuildListSize());
-					lastQueueSize = pBuilder->getProductionQueueSize();
-					lastUpgrading = pBuilder->isUpgrading();
-					lastBuildListSize = pBuilder->getBuildListSize();
+				// Each yard owns its concrete/structure placement sequence. Sharing
+				// a single FIFO lets the faster yard consume the other's locations.
+				auto& placeLocations = builderPlaceLocations[pBuilder->getObjectID()];
+				if (pBuilder->getProductionQueueSize() == 0) placeLocations.clear();
+				if (emitStatsLog) {
+					logDebug("PRODUCTION: CY=%u upgrading=%d queue=%d hold=%d credits=%d buildList=%d R/C/I=%d/%d/%d reserve=%u/%d",
+						pBuilder->getObjectID(), pBuilder->isUpgrading(), pBuilder->getProductionQueueSize(),
+						pBuilder->isOnHold(), money, pBuilder->getBuildListSize(),
+						itemCount[Structure_ZoneResidential], itemCount[Structure_ZoneCommercial],
+						itemCount[Structure_ZoneIndustrial], strategicReserveItem, strategicReserveCost);
 				}
 
 					if (!pBuilder->isUpgrading() && getHouse()->getCredits() > 100 && (pBuilder->getProductionQueueSize() < 1) && pBuilder->getBuildListSize()) {
@@ -2943,32 +3065,7 @@ void QuantBot::build(int militaryValue) {
 						// demand-AND-ratio rule used in the main zoning block,
 						// otherwise R-valve's wider range dominates and we end
 						// up R-only.
-						Uint32 zoneID = NONE_ID;
-						if (resCount == 0) {
-							zoneID = Structure_ZoneResidential;
-						} else if (indCount == 0) {
-							zoneID = Structure_ZoneIndustrial;
-						} else if (comCount == 0) {
-							zoneID = Structure_ZoneCommercial;
-						} else {
-							const int expR = std::max(comCount, indCount) * 3 + 3;
-							const int expI = std::max(resCount / 3, 1);
-							const int expC = std::max(resCount / 3, 1);
-							const int rGap = expR - resCount;
-							const int iGap = expI - indCount;
-							const int cGap = expC - comCount;
-							int bestGap = std::numeric_limits<int>::min();
-							if (ownResValve > 0 && rGap > bestGap) {
-								bestGap = rGap; zoneID = Structure_ZoneResidential;
-							}
-							if (ownIndValve > 0 && iGap > bestGap) {
-								bestGap = iGap; zoneID = Structure_ZoneIndustrial;
-							}
-							if (ownComValve > 0 && cGap > bestGap) {
-								bestGap = cGap; zoneID = Structure_ZoneCommercial;
-							}
-							if (zoneID == NONE_ID) zoneID = Structure_ZoneResidential;
-						}
+						const Uint32 zoneID = chooseCityZone(pBuilder, true);
 
 						if (zoneID != NONE_ID
 							&& money > 200
@@ -3207,6 +3304,7 @@ void QuantBot::build(int militaryValue) {
 					logDebug("Build IX... money: %d", money);
 				}
 				if (ixOverdue && !skipRemainingStructureLogic
+					&& itemCount[Structure_IX] == 0
 					&& stablePower
 					&& money > 1000
 					&& pBuilder->isAvailableToBuild(Structure_IX)
@@ -3216,11 +3314,9 @@ void QuantBot::build(int militaryValue) {
 					itemID = Structure_IX;
 				}
 				// 12. Additional Heavy Factories (expansion).
-				//     City sim: scale HF count with credits/sec income (same formula
-				//     as CY/MCV scaling). HFs should grow with the city economy, not
-				//     with raw treasury size — otherwise the AI hoards money and
-				//     spams factories with no use for them.
-				//     Non-city: keep money/4000 fallback.
+				//     Income supports steady expansion; large cash surpluses fund
+				//     extra tank capacity, bounded while military demand remains.
+				//     Non-city uses the existing money/4000 target, also bounded.
 				//     Requirements are progressive based on tech level:
 				//     Tech 4: No prerequisites (just money and need)
 				//     Tech 5-6: Require Repair Yard
@@ -3228,19 +3324,17 @@ void QuantBot::build(int militaryValue) {
 				if (itemID == NONE_ID && !skipRemainingStructureLogic
 								&& money > 2000 && pBuilder->isAvailableToBuild(Structure_HeavyFactory)) {
 
-								int desiredHFs = 1;
+								int creditsPerSec = 0;
 								if (isCitySim) {
 									auto* citySim = currentGame ? currentGame->getCitySimulation() : nullptr;
 									int tax = citySim ? citySim->getCityTax() : 7;
 									int32_t annual = DuneCity::computeAnnualTaxRevenue(ownTotalPop, tax, ownAvgLandValue);
-									int creditsPerSec = annual / 60;
-									desiredHFs = 1 + creditsPerSec / 50;
-								} else {
-									desiredHFs = 1 + money / 4000;
+									creditsPerSec = annual / 60;
 								}
+								const int desiredHFs = QuantBotBuildPolicy::desiredHeavyFactories(isCitySim, creditsPerSec, money);
 
-								const bool needMore = (activeHeavyFactoryCount >= itemCount[Structure_HeavyFactory])
-									|| (itemCount[Structure_HeavyFactory] < desiredHFs);
+								const bool needMore = itemCount[Structure_HeavyFactory] < desiredHFs
+									&& militaryValue < militaryValueLimit && !getHouse()->isGroundUnitLimitReached();
 
 								if (needMore) {
 									int techLevel = currentGame ? currentGame->techLevel : 8;
@@ -3348,7 +3442,8 @@ void QuantBot::build(int militaryValue) {
 				// 17b. Palace (after military infrastructure)
 				//       City sim: 1 palace per 30000 population
 				{
-				const bool palaceAllowed = palaceAllowedNow;
+				const bool palaceAllowed = itemCount[Structure_Palace] < palaceTarget
+					&& !orderedThisTick.count(Structure_Palace);
 				if (itemID == NONE_ID && !skipRemainingStructureLogic
 									&& money > 5000
 									&& pBuilder->isAvailableToBuild(Structure_Palace)
@@ -3419,9 +3514,8 @@ void QuantBot::build(int militaryValue) {
 					}
 				}
 
-				// Zone type is chosen by demand valves: build whichever R/I/C
-				// has the highest positive demand. Falls back to R if all
-				// valves are equal or negative.
+				// Rank zones by live demand and the R/I/C balance. Try the next
+				// candidate if the preferred zone has no available building site.
 				// In city sim, zones are the economic base — only windtrap is
 				// required so the AI doesn't gate growth behind military
 				// infrastructure that itself requires population (e.g. Starport
@@ -3449,40 +3543,17 @@ void QuantBot::build(int militaryValue) {
 								powerSurplus, kZonePowerHeadroom);
 						}
 					} else {
-						// Pick zone by demand AND target ratio (~3R : 1I : 1C).
-						// Pure valve picking is broken when all three valves
-						// saturate: R-valve range is ±2000 vs ±1500 for C/I, so
-						// at full demand R always wins and the city becomes
-						// pure-residential. Combine valve sign (live demand)
-						// with the count gap to the target ratio.
 						const int resCount = itemCount[Structure_ZoneResidential];
 						const int comCount = itemCount[Structure_ZoneCommercial];
 						const int indCount = itemCount[Structure_ZoneIndustrial];
-						const int expR = std::max(comCount, indCount) * 3 + 3;
-						const int expI = std::max(resCount / 3, 1);
-						const int expC = std::max(resCount / 3, 1);
-						const int rGap = expR - resCount;
-						const int iGap = expI - indCount;
-						const int cGap = expC - comCount;
-
-						Uint32 zoneID = NONE_ID;
-						int bestGap = std::numeric_limits<int>::min();
-						if (ownResValve > 0 && rGap > bestGap) {
-							bestGap = rGap; zoneID = Structure_ZoneResidential;
-						}
-						if (ownIndValve > 0 && iGap > bestGap) {
-							bestGap = iGap; zoneID = Structure_ZoneIndustrial;
-						}
-						if (ownComValve > 0 && cGap > bestGap) {
-							bestGap = cGap; zoneID = Structure_ZoneCommercial;
-						}
+						const Uint32 zoneID = chooseCityZone(pBuilder, false);
 
 						if (zoneID != NONE_ID && pBuilder->isAvailableToBuild(zoneID)
 							&& findPlaceLocation(zoneID).isValid()) {
 							itemID = zoneID;
-							logDebug("CITY-ZONE: Building %s (R:%d C:%d I:%d gap=%d valves=R%+d C%+d I%+d surplus=%d)",
+							logDebug("CITY-ZONE: Building %s (R:%d C:%d I:%d valves=R%+d C%+d I%+d surplus=%d)",
 								getItemNameByID(zoneID).c_str(), resCount, comCount, indCount,
-								bestGap, ownResValve, ownComValve, ownIndValve, powerSurplus);
+								ownResValve, ownComValve, ownIndValve, powerSurplus);
 						}
 					}
 				}
@@ -3502,6 +3573,20 @@ void QuantBot::build(int militaryValue) {
 						getItemNameByID(itemID).c_str());
 					itemID = NONE_ID;
 				}
+			}
+
+			// Retry useful economic work when another yard claimed the strategic
+			// order, or a chosen structure has no feasible footprint. Never
+			// default to residential regardless of demand or power.
+			if (itemID != NONE_ID && itemID != Structure_RocketTurret
+				&& itemID != Structure_GunTurret && !findPlaceLocation(itemID).isValid()) {
+				if (emitStatsLog) logDebug("PRODUCTION: CY=%u no site for item=%u", pBuilder->getObjectID(), itemID);
+				itemID = NONE_ID;
+			}
+			if (itemID == NONE_ID && !skipRemainingStructureLogic && isCitySim && money > 200
+				&& getHouse()->getProducedPower() - getHouse()->getPowerRequirement() >= 24
+				&& itemCount[Structure_WindTrap] > 0) {
+				itemID = chooseCityZone(pBuilder, false);
 			}
 
 			Coord selectedPlaceLocation = Coord::Invalid();
@@ -3574,9 +3659,15 @@ void QuantBot::build(int militaryValue) {
 					placeLocations.push_back(location);
 				}
 
-				orderedThisTick.insert(itemID);
-				produceItemWithLogging(itemID);
-				itemCount[itemID]++;
+				if (produceItemWithLogging(itemID)) {
+					orderedThisTick.insert(itemID);
+					itemCount[itemID]++;
+					money -= data[itemID][houseID].price;
+					if (itemID == strategicReserveItem) strategicReserveCost = 0;
+					placementCache.clear();
+				} else {
+					placeLocations.clear();
+				}
 			}
 			else if (itemID != NONE_ID && pBuilder->isAvailableToBuild(itemID)) {
 				// Only build concrete slabs to expand buildable area for structures that need it:
@@ -3604,28 +3695,16 @@ void QuantBot::build(int militaryValue) {
 		else if (itemID != NONE_ID && !pBuilder->isAvailableToBuild(itemID)) {
 			logDebug("Cannot build itemID %d: not available (prerequisites not met)", itemID);
 		}
-		else if (itemID == NONE_ID && !skipRemainingStructureLogic) {
+		else if (itemID == NONE_ID && !skipRemainingStructureLogic && emitStatsLog) {
 			logDebug("No structure selected to build (money: %d, skipRemaining: %d)", money, skipRemainingStructureLogic);
 		}
 		
-		// Proactive idle build. In city sim mode the AI should keep growing
-		// its economic base (residential zones) when there's nothing else to
-		// do — laying concrete in the desert burns credits and adds no income.
-		// Outside city sim, fall back to perimeter concrete.
-		if (money > 500 && pBuilder->getProductionQueueSize() < 1 && itemID == NONE_ID) {
-			if (isCitySim
-				&& itemCount[Structure_WindTrap] > 0
-				&& pBuilder->isAvailableToBuild(Structure_ZoneResidential)
-				&& findPlaceLocation(Structure_ZoneResidential).isValid()) {
-				doProduceItem(pBuilder, Structure_ZoneResidential);
-				logDebug("PROACTIVE: Building Residential Zone (idle CY, money: %d)", money);
-			} else if (!isCitySim && pBuilder->isAvailableToBuild(Structure_Slab1)) {
-				Coord slabLocation = findSlabPlaceLocation(Structure_Slab1);
-				if (slabLocation.isValid()) {
-					doProduceItem(pBuilder, Structure_Slab1);
-					logDebug("PROACTIVE: Building concrete slab to expand base (money: %d) at (%d,%d)", money, slabLocation.x, slabLocation.y);
-				}
-			}
+		// City yards use the demand-ranked fallback before placement above.
+		// Outside city mode an otherwise idle yard can extend concrete.
+		if (!isCitySim && money > 500 && pBuilder->getProductionQueueSize() < 1
+			&& itemID == NONE_ID && pBuilder->isAvailableToBuild(Structure_Slab1)) {
+			Coord slabLocation = findSlabPlaceLocation(Structure_Slab1);
+			if (slabLocation.isValid()) doProduceItem(pBuilder, Structure_Slab1);
 		}
 		
 						}
@@ -3678,6 +3757,7 @@ void QuantBot::build(int militaryValue) {
 
 						if (location.isValid()) {
 							doPlaceStructure(pConstYard, location.x, location.y);
+							placementCache.clear();
 							logDebug("PRODUCTION: Placed structure itemID: %d at (%d,%d)", itemToBePlaced, location.x, location.y);
 						}
 						else if (!alreadyCancelled) {

--- a/src/players/QuantBot.cpp
+++ b/src/players/QuantBot.cpp
@@ -2731,6 +2731,27 @@ void QuantBot::build(int militaryValue) {
 						pBuilder->isOnHold(), money, pBuilder->getBuildListSize(),
 						itemCount[Structure_ZoneResidential], itemCount[Structure_ZoneCommercial],
 						itemCount[Structure_ZoneIndustrial], strategicReserveItem, strategicReserveCost);
+					auto* balanceCity = currentGame ? currentGame->getCitySimulation() : nullptr;
+					const int taxIncome = citySimEnabled
+						? DuneCity::computeAnnualTaxRevenue(ownTotalPop, balanceCity ? balanceCity->getCityTax() : 7, ownAvgLandValue) / 60 : 0;
+					const int factoryTarget = QuantBotBuildPolicy::desiredHeavyFactories(citySimEnabled, taxIncome, money);
+					const int tech = currentGame ? currentGame->techLevel : 8;
+					const bool policyPrerequisites = citySimEnabled || tech <= 4
+						|| (itemCount[Structure_RepairYard] > 0 && (tech <= 6 || itemCount[Structure_IX] > 0));
+					const char* factoryReason = !pBuilder->isAvailableToBuild(Structure_HeavyFactory) ? "unavailable"
+						: money <= 2000 ? "cash-reserve"
+						: militaryValue >= militaryValueLimit ? "military-limit"
+						: getHouse()->isGroundUnitLimitReached() ? "unit-limit"
+						: itemCount[Structure_HeavyFactory] >= factoryTarget ? "target-met"
+						: !policyPrerequisites ? "tech-policy" : "expansion-due";
+					logDebug("BUILD-BALANCE: CY=%u HF=%d queued=%d busy=%d target=%d reason=%s RY=%d queued=%d busy=%d cap=%d taxPerSec=%d power=%d/%d",
+						pBuilder->getObjectID(), getHouse()->getNumItems(Structure_HeavyFactory),
+						itemCount[Structure_HeavyFactory] - getHouse()->getNumItems(Structure_HeavyFactory),
+						activeHeavyFactoryCount, factoryTarget, factoryReason,
+						getHouse()->getNumItems(Structure_RepairYard),
+						itemCount[Structure_RepairYard] - getHouse()->getNumItems(Structure_RepairYard),
+						activeRepairYardCount, QuantBotBuildPolicy::repairYardCap(getHouse()->getNumItems(Structure_HeavyFactory)),
+						taxIncome, getHouse()->getProducedPower(), getHouse()->getPowerRequirement());
 				}
 
 					if (!pBuilder->isUpgrading() && getHouse()->getCredits() > 100 && (pBuilder->getProductionQueueSize() < 1) && pBuilder->getBuildListSize()) {
@@ -3317,7 +3338,8 @@ void QuantBot::build(int militaryValue) {
 				//     Income supports steady expansion; large cash surpluses fund
 				//     extra tank capacity, bounded while military demand remains.
 				//     Non-city uses the existing money/4000 target, also bounded.
-				//     Requirements are progressive based on tech level:
+				//     City mode uses actual build availability; classic prerequisites remain.
+				//     Requirements outside city mode are progressive based on tech level:
 				//     Tech 4: No prerequisites (just money and need)
 				//     Tech 5-6: Require Repair Yard
 				//     Tech 7+: Require Repair Yard + IX
@@ -3340,8 +3362,8 @@ void QuantBot::build(int militaryValue) {
 									int techLevel = currentGame ? currentGame->techLevel : 8;
 									bool prerequisitesMet = false;
 
-									if (techLevel <= 4) {
-										// Tech 4: Can build additional Heavy Factories without prerequisites
+									if (isCitySim || techLevel <= 4) {
+										// City production uses the actual tech tree, not an extra IX policy gate.
 										prerequisitesMet = true;
 									}
 									else if (techLevel <= 6) {
@@ -3373,12 +3395,14 @@ void QuantBot::build(int militaryValue) {
 							itemCount[Unit_Harvester]++;
 						}
 					}
-				// 14. Additional Repair Yards (1 per 6000 military value)
+				// 14. Expand repair only when existing capacity is busy and production supports it.
 				if (itemID == NONE_ID && !skipRemainingStructureLogic
 							&& pBuilder->isAvailableToBuild(Structure_RepairYard) && money > 2000
-							&& itemCount[Structure_RepairYard] * 6000 < militaryValue) {
+							&& QuantBotBuildPolicy::needsExtraRepairYard(itemCount[Structure_RepairYard],
+								activeRepairYardCount, getHouse()->getNumItems(Structure_HeavyFactory), militaryValue)) {
 							itemID = Structure_RepairYard;
-							logDebug("Build Repair Yard: have %d, need %d (military: %d)", itemCount[Structure_RepairYard], (militaryValue / 6000) + 1, militaryValue);
+							logDebug("Build Repair Yard: have=%d busy=%d cap=%d military=%d", itemCount[Structure_RepairYard], activeRepairYardCount,
+								QuantBotBuildPolicy::repairYardCap(getHouse()->getNumItems(Structure_HeavyFactory)), militaryValue);
 						}
 				// 15. Additional High Tech Factories (if all existing ones are busy)
 				if (itemID == NONE_ID && !skipRemainingStructureLogic
@@ -3589,6 +3613,8 @@ void QuantBot::build(int militaryValue) {
 				itemID = chooseCityZone(pBuilder, false);
 			}
 
+			if (emitStatsLog) logDebug("BUILD-CHOICE: CY=%u item=%u credits=%d skip=%d",
+				pBuilder->getObjectID(), itemID, money, skipRemainingStructureLogic);
 			Coord selectedPlaceLocation = Coord::Invalid();
 			if (itemID != NONE_ID && pBuilder->isAvailableToBuild(itemID)) {
 				selectedPlaceLocation = (itemID == Structure_RocketTurret || itemID == Structure_GunTurret)

--- a/src/structures/BuilderBase.cpp
+++ b/src/structures/BuilderBase.cpp
@@ -312,6 +312,29 @@ void BuilderBase::updateProductionProgress() {
             if(productionProgress >= tmp->price) {
                 setWaitingToPlace();
             }
+        } else if(owner == pLocalHouse && productionProgress < tmp->price) {
+            // The queue is stalled and nothing tells the player why: say so in
+            // the log (every 10 s) and on the ticker (every 30 s).
+            static Uint32 lastStallLog = 0;
+            static Uint32 lastStallTicker = 0;
+            const Uint32 now = SDL_GetTicks();
+            const bool unitLimit = isUnitLimitReached(currentProducedItem);
+            const bool noCredits = owner->getCredits() <= 0;
+            if(now - lastStallLog >= 10000) {
+                lastStallLog = now;
+                SDL_Log("Production stalled: item %d in builder %u (item %d): onHold=%d unitLimit=%d (units %d/%d) credits=%d (city %ld, stored %ld, starting %ld)",
+                        currentProducedItem, getObjectID(), getItemID(),
+                        isOnHold() ? 1 : 0, unitLimit ? 1 : 0, owner->getNumUnits(), owner->getMaxUnits(),
+                        owner->getCredits(), lround(owner->getCityCredits()), lround(owner->getStoredCredits()), lround(owner->getStartingCredits()));
+            }
+            if(!isOnHold() && now - lastStallTicker >= 30000) {
+                lastStallTicker = now;
+                if(unitLimit) {
+                    currentGame->addToNewsTicker(_("Unit limit reached") + " (" + std::to_string(owner->getMaxUnits()) + ")");
+                } else if(noCredits) {
+                    currentGame->addToNewsTicker(_("Not enough money"));
+                }
+            }
         }
     }
 }

--- a/src/structures/ZoneStructure.cpp
+++ b/src/structures/ZoneStructure.cpp
@@ -69,25 +69,28 @@ void ZoneStructure::updateStructureSpecificStuff() {
     // Civic overlay: hospital/church sprites replace the normal zone art.
     // These are single-cell (1×1) atlases loaded as ObjPic_Hospital/Church.
     if (civicOverlay_ != CivicOverlay::None && density > 0) {
-        const int civicPic = (civicOverlay_ == CivicOverlay::Hospital)
+        // Keep the cache-refresh ID in sync with the single-cell layout.
+        // StructureBase::blitToScreen reloads by graphicID on every draw.
+        graphicID = (civicOverlay_ == CivicOverlay::Hospital)
             ? ObjPic_Hospital : ObjPic_Church;
-        graphic = pGFXManager->getObjPic(civicPic, getOwner()->getHouseID());
+        graphic = pGFXManager->getObjPic(graphicID, getOwner()->getHouseID());
         numImagesX = 1;
         numImagesY = 1;
         firstAnimFrame = lastAnimFrame = curAnimFrame = 0;
         return;
     }
 
-    // Restore normal zone atlas if overlay was cleared.
-    if (graphic != pGFXManager->getObjPic(graphicID, getOwner()->getHouseID())) {
-        graphic = pGFXManager->getObjPic(graphicID, getOwner()->getHouseID());
-        // Restore atlas dimensions per zone type.
-        if (graphicID == ObjPic_ZoneResidential || graphicID == ObjPic_ZoneCommercial) {
-            numImagesX = 4; numImagesY = 4;
-        } else if (graphicID == ObjPic_ZoneIndustrial) {
-            numImagesX = 4; numImagesY = 2;
-        }
+    // Restore both ID and layout when the civic overlay clears or the lot
+    // becomes vacant. Pointer equality cannot identify an atlas layout.
+    switch (zoneType_) {
+        case DuneCity::ZoneType::Residential: graphicID = ObjPic_ZoneResidential; break;
+        case DuneCity::ZoneType::Commercial: graphicID = ObjPic_ZoneCommercial; break;
+        case DuneCity::ZoneType::Industrial: graphicID = ObjPic_ZoneIndustrial; break;
+        default: return;
     }
+    graphic = pGFXManager->getObjPic(graphicID, getOwner()->getHouseID());
+    numImagesX = 4;
+    numImagesY = zoneType_ == DuneCity::ZoneType::Industrial ? 2 : 4;
 
     int valueT = 0;
     if (auto* citySim = currentGame ? currentGame->getCitySimulation() : nullptr;
@@ -156,6 +159,7 @@ bool ZoneStructure::canBePlacedAt(int x, int y, bool torch) const {
             }
         }
     }
+    int anchoredTiles = 0;
     for (int y1 = 0; y1 < structureSize.y; y1++) {
         for (int x1 = 0; x1 < structureSize.x; x1++) {
             Tile* pTile = currentGameMap->getTile(x + x1, y + y1);
@@ -163,10 +167,17 @@ bool ZoneStructure::canBePlacedAt(int x, int y, bool torch) const {
                 return false;
             }
             auto terrain = pTile->getType();
-            if (terrain != Terrain_Rock && terrain != Terrain_Slab) {
+            if (!DuneCity::isCityZoneTerrain(terrain)) {
                 return false;
             }
+            if (DuneCity::isCityBuildableTerrain(terrain)) {
+                anchoredTiles++;
+            }
         }
+    }
+    // A lot may reach onto sand, but at least one tile must sit on rock.
+    if (anchoredTiles == 0) {
+        return false;
     }
 
     // Trigger milestone notification for first zone built

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(dunelegacy_tests)
 # Note: Catch2WithMain provides main(), no testmain.cpp needed
 target_sources(dunelegacy_tests
     PRIVATE
+        RendererSizeTestCase.cpp
+        QuantBotBuildPolicyTestCase.cpp
         PathBudgetTestCase/PathBudgetTestCase.cpp
         NetworkManagerTestCase/NetworkManagerTestCase.cpp
         GenericNinthHouseRegressionTestCase/GenericNinthHouseRegressionTestCase.cpp
@@ -89,6 +91,20 @@ target_link_libraries(dunelegacy_tests
         $<IF:$<TARGET_EXISTS:SDL2_mixer::SDL2_mixer>,SDL2_mixer::SDL2_mixer,SDL2_mixer::SDL2_mixer-static>
         CURL::libcurl
 )
+
+if(APPLE)
+    # fnkdat.cpp calls getMacApplicationSupportFolder(), which is implemented in
+    # the Objective-C helper the game target also compiles (src/CMakeLists.txt).
+    target_sources(dunelegacy_tests PRIVATE ${CMAKE_SOURCE_DIR}/IDE/xCode/MacFunctions.m)
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/IDE/xCode/MacFunctions.m
+        PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+    target_link_libraries(dunelegacy_tests
+        PRIVATE
+            "-framework Cocoa"
+            "-framework Foundation"
+            "-framework CoreFoundation"
+    )
+endif()
 
 if(WIN32)
     target_link_libraries(dunelegacy_tests

--- a/tests/QuantBotBuildPolicyTestCase.cpp
+++ b/tests/QuantBotBuildPolicyTestCase.cpp
@@ -1,0 +1,52 @@
+#include <catch2/catch_test_macros.hpp>
+#include <players/QuantBotBuildPolicy.h>
+
+using namespace QuantBotBuildPolicy;
+
+TEST_CASE("QuantBot respects the single-palace option even in a large city", "[quantbot][production]") {
+    REQUIRE(palaceTarget(true, true, 60000) == 1);
+    REQUIRE(palaceTarget(false, false, 60000) == 1);
+    REQUIRE(palaceTarget(false, true, 29999) == 1);
+    REQUIRE(palaceTarget(false, true, 30000) == 2);
+    REQUIRE(palaceTarget(false, true, 60000) == 3);
+}
+
+TEST_CASE("QuantBot strategic savings leave excess funds available for tanks", "[quantbot][production]") {
+    REQUIRE(spendableCredits(59044, 2000) == 57044);
+    REQUIRE(spendableCredits(1000, 2000) == 0);
+    REQUIRE(spendableCredits(1000, 0) == 1000);
+    REQUIRE(spendableCredits(-100, 2000) == 0);
+}
+
+TEST_CASE("QuantBot repairs an over-residential economy even at saturated demand", "[quantbot][city]") {
+    const auto zones = rankZones(60, 4, 9, 2000, 1500, 1500, false);
+    REQUIRE(zones[0] == Structure_ZoneCommercial);
+    REQUIRE(zones[1] == Structure_ZoneIndustrial);
+    REQUIRE(zones[2] == Structure_ZoneResidential);
+    // The second yard sees the first yard's accepted order in its counts.
+    const auto first = rankZones(30, 10, 10, 2000, 1500, 1500, false);
+    REQUIRE(first[0] == Structure_ZoneResidential);
+    const auto second = rankZones(33, 10, 10, 2000, 1500, 1500, false);
+    REQUIRE(second[0] == Structure_ZoneIndustrial);
+}
+
+TEST_CASE("QuantBot does not build residential as a fallback against demand", "[quantbot][city]") {
+    const auto zones = rankZones(60, 4, 9, -286, 1500, 1500, false);
+    REQUIRE(zones[0] == Structure_ZoneCommercial);
+    REQUIRE(zones[1] == Structure_ZoneIndustrial);
+    REQUIRE(zones[2] == NONE_ID);
+    for(auto item : rankZones(3, 1, 1, 0, -100, -100, false)) REQUIRE(item == NONE_ID);
+}
+
+TEST_CASE("QuantBot seeds missing jobs before relying on positive demand", "[quantbot][city]") {
+    REQUIRE(rankZones(3, 0, 0, 2000, -1500, -1500, true)[0] == Structure_ZoneIndustrial);
+    REQUIRE(rankZones(3, 0, 1, 2000, -1500, -1500, true)[0] == Structure_ZoneCommercial);
+}
+
+TEST_CASE("QuantBot expands tank production with surplus cash without unbounded factory growth", "[quantbot][production]") {
+    REQUIRE(desiredHeavyFactories(true, 50, 59044) == 6);
+    REQUIRE(desiredHeavyFactories(true, 150, 3000) == 4);
+    REQUIRE(desiredHeavyFactories(true, 0, 2000) == 1);
+    REQUIRE(desiredHeavyFactories(true, 10000, 1000000) == 8);
+    REQUIRE(desiredHeavyFactories(false, 0, 12000) == 4);
+}

--- a/tests/QuantBotBuildPolicyTestCase.cpp
+++ b/tests/QuantBotBuildPolicyTestCase.cpp
@@ -44,9 +44,34 @@ TEST_CASE("QuantBot seeds missing jobs before relying on positive demand", "[qua
 }
 
 TEST_CASE("QuantBot expands tank production with surplus cash without unbounded factory growth", "[quantbot][production]") {
-    REQUIRE(desiredHeavyFactories(true, 50, 59044) == 6);
+    REQUIRE(desiredHeavyFactories(true, 50, 59044) == 8);
     REQUIRE(desiredHeavyFactories(true, 150, 3000) == 4);
     REQUIRE(desiredHeavyFactories(true, 0, 2000) == 1);
     REQUIRE(desiredHeavyFactories(true, 10000, 1000000) == 8);
     REQUIRE(desiredHeavyFactories(false, 0, 12000) == 4);
+}
+
+TEST_CASE("QuantBot converts the observed city cash surplus into troop capacity", "[quantbot][production]") {
+    REQUIRE(desiredHeavyFactories(true, 0, 6999) == 1);
+    REQUIRE(desiredHeavyFactories(true, 0, 7000) == 2);
+    REQUIRE(desiredHeavyFactories(true, 0, 11926) == 2);
+    REQUIRE(desiredHeavyFactories(true, 0, 13873) == 3);
+    REQUIRE(desiredHeavyFactories(true, 0, 17922) == 4);
+    REQUIRE(desiredHeavyFactories(true, 0, -100) == 1);
+}
+
+TEST_CASE("QuantBot repair expansion follows load and heavy production capacity", "[quantbot][production]") {
+    // Current-game regressions: four/six yards with just two factories.
+    REQUIRE_FALSE(needsExtraRepairYard(3, 3, 2, 19520));
+    REQUIRE_FALSE(needsExtraRepairYard(5, 5, 2, 30200));
+    REQUIRE_FALSE(needsExtraRepairYard(1, 1, 2, 19520));
+    // Productive army with a busy repair yard can add a second.
+    REQUIRE(needsExtraRepairYard(1, 1, 3, 19520));
+    REQUIRE_FALSE(needsExtraRepairYard(1, 0, 3, 19520));
+    // One busy yard plus another queued must not trigger a third order.
+    REQUIRE_FALSE(needsExtraRepairYard(2, 1, 6, 30000));
+    REQUIRE(needsExtraRepairYard(2, 2, 6, 30000));
+    REQUIRE_FALSE(needsExtraRepairYard(2, 2, 6, 12000));
+    REQUIRE_FALSE(needsExtraRepairYard(0, 0, 0, 30000));
+    REQUIRE_FALSE(needsExtraRepairYard(4, 4, 20, 80000));
 }

--- a/tests/RendererSizeTestCase.cpp
+++ b/tests/RendererSizeTestCase.cpp
@@ -1,0 +1,51 @@
+#include <catch2/catch_test_macros.hpp>
+#include <misc/DrawingRectHelper.h>
+#include <cstdlib>
+
+TEST_CASE("Renderer dimensions follow the active target and restore the window layout", "[rendering]") {
+    sdl2::surface_ptr surface{SDL_CreateRGBSurfaceWithFormat(0, 1280, 800, 32, SDL_PIXELFORMAT_RGBA32)};
+    REQUIRE(surface);
+    // Opt into the native HiDPI backend locally; software rendering also runs
+    // on headless CI, but does not reproduce sdl2-compat's output-size bug.
+    const bool native = std::getenv("DUNECITY_RENDERER_TEST_GPU") != nullptr;
+    struct VideoSubsystem {
+        bool active;
+        ~VideoSubsystem() { if(active) SDL_QuitSubSystem(SDL_INIT_VIDEO); }
+    } video{native};
+    if(native) REQUIRE(SDL_InitSubSystem(SDL_INIT_VIDEO) == 0);
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window{
+        native ? SDL_CreateWindow("Renderer size regression", 0, 0, 1280, 800,
+                                  SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI) : nullptr,
+        SDL_DestroyWindow};
+    if(native) REQUIRE(window);
+    sdl2::renderer_ptr testRenderer{native
+        ? SDL_CreateRenderer(window.get(), -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE)
+        : SDL_CreateSoftwareRenderer(surface.get())};
+    REQUIRE(testRenderer);
+    struct RestoreRenderer {
+        SDL_Renderer* previous = renderer;
+        ~RestoreRenderer() { renderer = previous; }
+    } restoreRenderer;
+    renderer = testRenderer.get();
+
+    int outputWidth = 0, outputHeight = 0;
+    REQUIRE(SDL_GetRendererOutputSize(renderer, &outputWidth, &outputHeight) == 0);
+    REQUIRE(getRendererWidth() == outputWidth);
+    REQUIRE(getRendererHeight() == outputHeight);
+    REQUIRE(SDL_RenderSetLogicalSize(renderer, 960, 600) == 0);
+    REQUIRE(getRendererWidth() == 960);
+    REQUIRE(getRendererHeight() == 600);
+
+    sdl2::texture_ptr target{SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
+                                              SDL_TEXTUREACCESS_TARGET, 960, 600)};
+    REQUIRE(target);
+    REQUIRE(SDL_SetRenderTarget(renderer, target.get()) == 0);
+    REQUIRE(getRendererWidth() == 960);
+    REQUIRE(getRendererHeight() == 600);
+    // The rightmost credits glyph must remain inside the sidebar and target.
+    const int creditsRight = getRendererWidth() - 144 + 49 + 5 * 10 + 8;
+    REQUIRE(creditsRight == 923);
+    REQUIRE(SDL_SetRenderTarget(renderer, nullptr) == 0);
+    REQUIRE(getRendererWidth() == 960);
+    REQUIRE(getRendererHeight() == 600);
+}

--- a/tests/ZoneStructureTestCase/ZoneStructureTestCase.cpp
+++ b/tests/ZoneStructureTestCase/ZoneStructureTestCase.cpp
@@ -170,15 +170,18 @@ TEST_CASE("ZoneStructure: header declares setLocation override",
     REQUIRE(hdr.find("override") != std::string::npos);
 }
 
-TEST_CASE("ZoneStructure: placement rejects sand and accepts rock or slab",
+TEST_CASE("ZoneStructure: placement allows sand only when anchored on rock or slab",
           "[zone][placement][sand][regression]") {
     std::string src = readSourceFile("src/structures/ZoneStructure.cpp");
     REQUIRE_FALSE(src.empty());
 
     std::string body = extractFunctionBody(src, "ZoneStructure::canBePlacedAt(");
     REQUIRE_FALSE(body.empty());
-    REQUIRE(body.find("terrain != Terrain_Rock && terrain != Terrain_Slab") != std::string::npos);
-    REQUIRE(body.find("Terrain_Sand") == std::string::npos);
+    // Every tile must be zone terrain (rock, slab, sand or dunes) ...
+    REQUIRE(body.find("isCityZoneTerrain") != std::string::npos);
+    // ... and at least one tile must be rock or slab.
+    REQUIRE(body.find("isCityBuildableTerrain") != std::string::npos);
+    REQUIRE(body.find("anchoredTiles == 0") != std::string::npos);
 }
 
 // =============================================================================
@@ -494,6 +497,33 @@ TEST_CASE("ZoneStructure: GFXManager skips SDL_SetColorKey for truecolor zone sp
 }
 
 // =============================================================================
+TEST_CASE("ZoneStructure: civic art survives the renderer texture refresh",
+          "[zone][graphics][civic][regression]") {
+    const auto zone = extractFunctionBody(readSourceFile("src/structures/ZoneStructure.cpp"),
+                                           "void ZoneStructure::updateStructureSpecificStuff()");
+    const auto draw = extractFunctionBody(readSourceFile("src/structures/StructureBase.cpp"),
+                                           "void StructureBase::blitToScreen()");
+    REQUIRE_FALSE(zone.empty());
+    REQUIRE_FALSE(draw.empty());
+    // The render path re-resolves the texture by ID. Setting only `graphic`
+    // in the update path draws a 4x4 atlas using the civic 1x1 frame layout.
+    REQUIRE(draw.find("getObjPic(graphicID, owner->getHouseID())") != std::string::npos);
+    const auto civic = extractFunctionBody(zone, "if (civicOverlay_ != CivicOverlay::None && density > 0)");
+    REQUIRE(civic.find("graphicID =") != std::string::npos);
+    REQUIRE(civic.find("ObjPic_Hospital : ObjPic_Church") != std::string::npos);
+    REQUIRE(civic.find("getObjPic(graphicID,") != std::string::npos);
+    REQUIRE(civic.find("numImagesX = 1") != std::string::npos);
+    REQUIRE(civic.find("numImagesY = 1") != std::string::npos);
+    // Clearing a civic overlay (including a vacant lot) restores the normal
+    // atlas ID and dimensions, without depending on cached pointer equality.
+    const auto restore = zone.substr(zone.find("switch (zoneType_)"));
+    REQUIRE(restore.find("graphicID = ObjPic_ZoneResidential") != std::string::npos);
+    REQUIRE(restore.find("graphicID = ObjPic_ZoneCommercial") != std::string::npos);
+    REQUIRE(restore.find("graphicID = ObjPic_ZoneIndustrial") != std::string::npos);
+    REQUIRE(restore.find("numImagesX = 4") != std::string::npos);
+    REQUIRE(restore.find("ZoneType::Industrial ? 2 : 4") != std::string::npos);
+}
+
 // Zone animation frame regression tests
 //
 // StructureBase::init() defaults firstAnimFrame = lastAnimFrame = curAnimFrame = 2,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dunecity",
-  "version": "1.0.535",
+  "version": "1.0.536",
   "description": "Dune City - A modern OpenSource Dune 2 engine with city simulation",
   "homepage": "https://dunelegacy.sourceforge.net",
   "dependencies": [


### PR DESCRIPTION
Credits and dynamically right-aligned UI elements could be drawn outside the offscreen render target under sdl2-compat, and QuantBot construction yards could reserve their loops for rejected structures or repeat one zone type while heavy factories remained underused. This change fixes target-size detection, per-yard placement plans, zoning balance, factory and repair capacity policy, civic texture refresh, and the related game settings.

It also makes macOS releases operational on an Apple Silicon self-hosted runner. The release job now excludes pull requests, uses a dedicated runner label, bundles non-system dylibs into the app, generates correct bundle metadata, mounts and validates the DMG before upload, and retains the existing tag-driven GitHub Release and dunelegacy.com update path.

Validation:

- Full GitHub Actions run passed on Windows, Linux, and macOS: https://github.com/VR48/dunecity/actions/runs/34010340839
- Version 1.0.536 macOS build, DMG verification, and artifact upload passed: https://github.com/VR48/dunecity/actions/runs/34011021788
- Final gameplay-head macOS build, DMG verification, artifact upload, Linux tests, and Linux packages passed: https://github.com/VR48/dunecity/actions/runs/34010750435
- Warm-cache macOS build completed in 1m58s.
- Local DMG verification passed for ARM64 architecture, bundle metadata, bundled dylib paths, game data, Applications link, and code signature.
- Local tests: 372 passed, 2 pre-existing `parseDouble("nan")` failures on macOS, 3 skipped.
